### PR TITLE
SCHED-250: Change how time calculations are handled

### DIFF
--- a/lucupy/minimodel/group.py
+++ b/lucupy/minimodel/group.py
@@ -121,7 +121,7 @@ class Group(ABC):
         if issubclass(type(self.children), Observation):
             return self.children.exec_time()
         else:
-            sum(child.exec_time() for child in self.children)
+            sum((child.exec_time() for child in self.children), timedelta())
 
     def program_used(self) -> timedelta:
         """Program time used across the group.
@@ -132,7 +132,7 @@ class Group(ABC):
         if issubclass(type(self.children), Observation):
             return self.children.program_used()
         else:
-            return sum(child.program_used() for child in self.children)
+            return sum((child.program_used() for child in self.children), timedelta())
 
     def partner_used(self) -> timedelta:
         """Partner time used across the group.
@@ -143,7 +143,7 @@ class Group(ABC):
         if issubclass(type(self.children), Observation):
             return self.children.partner_used()
         else:
-            return sum(child.partner_used() for child in self.children)
+            return sum((child.partner_used() for child in self.children), timedelta())
 
     def total_used(self) -> timedelta:
         """Total time used across the group: includes program time and partner time.
@@ -154,7 +154,7 @@ class Group(ABC):
         if issubclass(type(self.children), Observation):
             return self.children.total_used()
         else:
-            return sum(child.total_used() for child in self.children)
+            return sum((child.total_used() for child in self.children), timedelta())
 
     def show(self, depth: int = 1) -> NoReturn:
         """Print content of the Group.

--- a/lucupy/minimodel/group.py
+++ b/lucupy/minimodel/group.py
@@ -112,14 +112,58 @@ class Group(ABC):
         """
         return not (self.is_observation_group())
 
+    def exec_time(self) -> timedelta:
+        """Total execution time across the children of this group.
+
+        Returns:
+            exec_time (timedelta): Sum of all the execution times.
+        """
+        if issubclass(type(self.children), Observation):
+            return self.children.exec_time()
+        else:
+            sum(child.exec_time() for child in self.children)
+
+    def program_used(self) -> timedelta:
+        """Program time used across the group.
+
+        Returns:
+            program_used (timedelta): Sum of all program_used times across children of this group.
+        """
+        if issubclass(type(self.children), Observation):
+            return self.children.program_used()
+        else:
+            return sum(child.program_used() for child in self.children)
+
+    def partner_used(self) -> timedelta:
+        """Partner time used across the group.
+
+        Returns:
+            partner_time (timedelta): Sum of all `partner_used` across the children of this group.
+        """
+        if issubclass(type(self.children), Observation):
+            return self.children.partner_used()
+        else:
+            return sum(child.partner_used() for child in self.children)
+
+    def total_used(self) -> timedelta:
+        """Total time used across the group: includes program time and partner time.
+
+        Returns:
+            total_used (timedelta): Sum of total_used times across all children.
+        """
+        if issubclass(type(self.children), Observation):
+            return self.children.total_used()
+        else:
+            return sum(child.total_used() for child in self.children)
+
     def show(self, depth: int = 1) -> NoReturn:
         """Print content of the Group.
 
         Args:
             depth (int, optional): depth of the separator. Defaults to 1.
         """
-        def sep(depth: int) -> str:
-            return '----- ' * depth
+        def sep(indent: int) -> str:
+            return '----- ' * indent
         # Is this a subgroup or an observation?
         if isinstance(self.children, Observation):
             self.children.show(depth)
@@ -190,28 +234,6 @@ class AndGroup(Group):
 
     def is_or_group(self) -> bool:
         return False
-
-    def exec_time(self) -> timedelta:
-        """Total execution time across the children of this group.
-
-        Returns:
-            exec_time (timedelta): Sum of all the executions time.
-        """
-        if issubclass(type(self.children), Observation):
-            return self.children.exec_time()
-        else:
-            sum(child.exec_time() for child in self.children)
-
-    def total_used(self) -> timedelta:
-        """Total time used across the group: includes program time and partner time.
-
-        Returns:
-            total_used (timedelta): Sum of all total used times.
-        """
-        if issubclass(type(self.children), Observation):
-            return self.children.total_used()
-        else:
-            sum(child.total_used() for child in self.children)
 
     def instruments(self) -> FrozenSet[Resource]:
         """

--- a/lucupy/minimodel/group.py
+++ b/lucupy/minimodel/group.py
@@ -28,9 +28,10 @@ class Group(ABC):
     Attributes:
         id (GroupID): the identification of the group.
         group_name (str): a human-readable name of the group.
-        number_to_observe (int): the number of children in the group that must be observed for the group to be considered complete.
+        number_to_observe (int): the number of children in the group that must be observed for the group to be
+                                 considered complete.
         delay_min(timedelta): used in cadences.
-        delay_ma(timedelta): used in cadences.
+        delay_max(timedelta): used in cadences.
         children (Union[List['Group'], Observation]): member(s) of the group
     """
     id: GroupID
@@ -46,7 +47,7 @@ class Group(ABC):
             raise ValueError(msg)
 
     def subgroup_ids(self) -> FrozenSet[GroupID]:
-        """Get the ids for all the sub-groups inside.
+        """Get the ids for all the subgroups inside.
 
         Returns:
             FrozenSet[GroupID]: Set of GroupID values.

--- a/lucupy/minimodel/observation.py
+++ b/lucupy/minimodel/observation.py
@@ -262,8 +262,8 @@ class Observation:
         Args:
             depth (int, optional): depth of the separator. Defaults to 1.
         """
-        def sep(depth: int) -> str:
-            return '----- ' * depth
+        def sep(indent: int) -> str:
+            return '----- ' * indent
 
         print(f'{sep(depth)} Observation: {self.id}')
         for atom in self.sequence:

--- a/lucupy/minimodel/program.py
+++ b/lucupy/minimodel/program.py
@@ -99,20 +99,29 @@ class Program:
     def program_awarded(self) -> timedelta:
         return sum((t.program_awarded for t in self.allocated_time), timedelta())
 
-    def program_used(self) -> timedelta:
+    def program_awarded_used(self) -> timedelta:
         return sum((t.program_used for t in self.allocated_time), timedelta())
 
     def partner_awarded(self) -> timedelta:
         return sum((t.partner_awarded for t in self.allocated_time), timedelta())
 
-    def partner_used(self) -> timedelta:
+    def partner_awarded_used(self) -> timedelta:
         return sum((t.partner_used for t in self.allocated_time), timedelta())
 
     def total_awarded(self) -> timedelta:
         return sum((t.total_awarded() for t in self.allocated_time), timedelta())
 
-    def total_used(self) -> timedelta:
+    def total_awarded_used(self) -> timedelta:
         return sum((t.total_used() for t in self.allocated_time), timedelta())
+
+    def program_used(self) -> timedelta:
+        return self.root_group.program_used()
+
+    def partner_used(self) -> timedelta:
+        return self.root_group.partner_used()
+
+    def total_used(self) -> timedelta:
+        return self.root_group.total_used()
 
     def observations(self) -> List[Observation]:
         return self.root_group.observations()

--- a/lucupy/observatory/gemini/geminiobservation.py
+++ b/lucupy/observatory/gemini/geminiobservation.py
@@ -10,7 +10,7 @@ from .geminiproperties import GeminiProperties
 
 def with_igrins_cal(func):
     def add_calibration(self):
-        if GeminiProperties.Instruments.IGRINS in self.required_resources() and self.partner_used() > 0:
+        if GeminiProperties.Instruments.IGRINS in self.required_resources() and self.partner_awarded_used() > 0:
             return func(self) + timedelta(seconds=(1 / 6))
         return func(self)
 

--- a/lucupy/observatory/gemini/geminiobservation.py
+++ b/lucupy/observatory/gemini/geminiobservation.py
@@ -10,7 +10,7 @@ from .geminiproperties import GeminiProperties
 
 def with_igrins_cal(func):
     def add_calibration(self):
-        if GeminiProperties.Instruments.IGRINS in self.required_resources() and self.partner_awarded_used() > 0:
+        if GeminiProperties.Instruments.IGRINS in self.required_resources() and self.partner_used() > 0:
             return func(self) + timedelta(seconds=(1 / 6))
         return func(self)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.7"
+version = "0.1.8"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = ["Sergio Troncoso <sergio.troncoso@noirlab.edu>",
            "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.5"
+version = "0.1.6"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = ["Sergio Troncoso <sergio.troncoso@noirlab.edu>",
            "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.6"
+version = "0.1.7"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = ["Sergio Troncoso <sergio.troncoso@noirlab.edu>",
            "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",


### PR DESCRIPTION
This is a substantial refactor of time calculations:

1. Logic for time calculation has now been moved from `AndGroup` to `Group`.
2. `Program` now differentiates between awarded time used and time used across `Observation`s / `Group`s.
3. Bugfix: missing `return` for `sum`.
4. Bugfix: rewrote `sum` statements to use a generator and a default of `timedelta()` for the zero element. (Before `int` was assumed, causing an error.)
5. Warnings cleared.