### PR TITLE
SCHED-276: Add ProgramID and a unique_id method to Group

### DIFF
--- a/lucupy/minimodel/__init__.py
+++ b/lucupy/minimodel/__init__.py
@@ -6,6 +6,7 @@
 from .atom import *
 from .constraints import *
 from .group import *
+from .ids import *
 from .magnitude import *
 from .observation import *
 from .observationmode import *

--- a/lucupy/minimodel/ids.py
+++ b/lucupy/minimodel/ids.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+# For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+ProgramID = str
+GroupID = str
+UniqueGroupID = str
+ObservationID = str

--- a/lucupy/minimodel/observation.py
+++ b/lucupy/minimodel/observation.py
@@ -10,14 +10,13 @@ from lucupy.observatory.abstract import ObservatoryProperties
 
 from .atom import Atom
 from .constraints import Constraints
+from .ids import ObservationID
 from .qastate import QAState
 from .resource import Resource
 from .site import Site
 from .target import Target, TargetType
 from .too import TooType
 from ..types import ZeroTime
-
-ObservationID = str
 
 
 class ObservationStatus(IntEnum):

--- a/lucupy/minimodel/program.py
+++ b/lucupy/minimodel/program.py
@@ -6,14 +6,13 @@ from datetime import datetime, timedelta
 from enum import Enum, IntEnum, auto
 from typing import ClassVar, FrozenSet, List, Optional
 
-from .group import AndGroup, Group, GroupID
+from .group import AndGroup, Group
+from .ids import ProgramID, GroupID
 from .observation import Observation
 from .semester import Semester
 from .timeallocation import TimeAllocation
 from .too import TooType
 from ..types import ZeroTime
-
-ProgramID = str
 
 
 class Band(IntEnum):

--- a/poetry.lock
+++ b/poetry.lock
@@ -439,7 +439,7 @@ mkdocs = ">=1.1,<2.0"
 
 [[package]]
 name = "mkdocstrings"
-version = "0.19.0"
+version = "0.19.1"
 description = "Automatic documentation from sources, for MkDocs."
 category = "dev"
 optional = false
@@ -1024,8 +1024,8 @@ mkdocs-section-index = [
     {file = "mkdocs_section_index-0.3.4-py3-none-any.whl", hash = "sha256:214f7a6df9d35a5772e9577f3899ff3edd90044064589e6dd4d84615b72a8024"},
 ]
 mkdocstrings = [
-    {file = "mkdocstrings-0.19.0-py3-none-any.whl", hash = "sha256:3217d510d385c961f69385a670b2677e68e07b5fea4a504d86bf54c006c87c7d"},
-    {file = "mkdocstrings-0.19.0.tar.gz", hash = "sha256:efa34a67bad11229d532d89f6836a8a215937548623b64f3698a1df62e01cc3e"},
+    {file = "mkdocstrings-0.19.1-py3-none-any.whl", hash = "sha256:32a38d88f67f65b264184ea71290f9332db750d189dea4200cbbe408d304c261"},
+    {file = "mkdocstrings-0.19.1.tar.gz", hash = "sha256:d1037cacb4b522c1e8c164ed5d00d724a82e49dcee0af80db8fb67b384faeef9"},
 ]
 mkdocstrings-python = [
     {file = "mkdocstrings-python-0.8.2.tar.gz", hash = "sha256:b22528b7a7a0589d007eced019d97ad14de4eba4b2b9ba6a013bb66edc74ab43"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.14"
+version = "0.1.15"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = ["Sergio Troncoso <sergio.troncoso@noirlab.edu>",
            "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,10 +1,64 @@
 # Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
+from datetime import timedelta
+
 import astropy.units as u
 import pytest
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.time import Time
+
+from lucupy.minimodel import (AndGroup, AndOption, Observation, ObservationClass, ObservationStatus, Priority,
+                              SetupTimeType, Site)
+
+
+@pytest.fixture
+def observation():
+    return Observation(
+        id='GN-2018B-Q-101-1337',
+        internal_id="",
+        order=1,
+        title='Test observation',
+        site=Site.GN,
+        status=ObservationStatus.READY,
+        active=True,
+        priority=Priority.MEDIUM,
+        setuptime_type=SetupTimeType.NONE,
+        acq_overhead=timedelta(),
+        obs_class=ObservationClass.SCIENCE,
+        targets=[],
+        guiding={},
+        sequence=[],
+        constraints=None,
+    )
+
+
+@pytest.fixture
+def observation_group(observation):
+    return AndGroup(
+        id='GN-2018B-Q-101-1337',
+        program_id='GN-2018B-Q-101',
+        group_name='Test observation group',
+        number_to_observe=1,
+        delay_min=timedelta(),
+        delay_max=timedelta(),
+        children=observation,
+        group_option=AndOption.ANYORDER
+    )
+
+
+@pytest.fixture
+def scheduling_group(observation_group):
+    return AndGroup(
+        id='10',
+        program_id='GN-2018B-Q-101',
+        group_name='Test scheduling group',
+        number_to_observe=1,
+        delay_min=timedelta(),
+        delay_max=timedelta(),
+        children=[observation_group],
+        group_option=AndOption.ANYORDER
+    )
 
 
 @pytest.fixture

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+# For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+import pytest
+
+from .fixtures import observation, observation_group, scheduling_group
+
+
+@pytest.mark.usefixtures('observation_group')
+def test_unique_observation_group_id(observation_group):
+    """
+    Test a unique ID for an observation group.
+    """
+    assert observation_group.unique_id() == observation_group.id
+
+
+@pytest.mark.usefixtures('scheduling_group')
+def test_unique_scheduling_group_id(scheduling_group):
+    """
+    Test a unique ID for a scheduling group.
+    """
+    assert scheduling_group.unique_id() == f'{scheduling_group.program_id}:{scheduling_group.id}'

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -18,6 +18,7 @@ def test_print_program():
     """
     Test the print_program function.
     """
+    program_id = 'test_program'
 
     o = Observation(
         id='test_observation',
@@ -41,6 +42,7 @@ def test_print_program():
     # Create the trivial AND group containing the gnirs1 observation.
     g1 = AndGroup(
         id='test_group',
+        program_id=program_id,
         group_name='test',
         number_to_observe=1,
         delay_min=None,
@@ -50,6 +52,7 @@ def test_print_program():
     )
 
     g = AndGroup(id='root',
+                 program_id=program_id,
                  group_name='root',
                  number_to_observe=1,
                  delay_min=None,
@@ -58,7 +61,7 @@ def test_print_program():
                  group_option=None,
                  )
     p = Program(
-        id='test_program',
+        id=program_id,
         internal_id='c396b9c9-9bdd-4eec-be83-81162090d032',
         semester=None,
         band=None,


### PR DESCRIPTION
Scheduling groups from OCS have names that are just integers, and thus do not make a lot of sense. They can also clash between programs, so, e.g., two programs could have a scheduling group with the name of `10`.

Now a `program_id` field has been added to `Group`, and a `unique_id` method that:

1.  In the case of an observation group, just returns the name of the observation in the group.
2. In the case of a scheduling group (including the root group) has the name of the form `program_id:group_id` to make it unique and human-readable.

Test fixtures and cases have been added as well.

Additionally, all ID aliases were moved to their own file, because this introduced circular dependencies.