### PR TITLE
SCHED-270: immutable decorator and suppression of deepcopy of immutable objects

### DIFF
--- a/lucupy/decorators/__init__.py
+++ b/lucupy/decorators/__init__.py
@@ -1,12 +1,14 @@
 # Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 import numpy as np
 
 
 def scalar_input(func):
     """
     Decorator to convert a function that returns a tuple to a function that returns a scalar.
-    TODO: TO IMPLEMENT THIS IS NECESSARY TO REMOVE ASTROPY outputs or made them numpy compatible.
+    TODO: This is not currently being used. Ultimately, we would add it to the functions in the sky package.
+    TODO: TO IMPLEMENT THIS IS NECESSARY TO REMOVE ASTROPY outputs or make them numpy compatible.
     """
 
     def wrapper(*args, **kwargs):
@@ -18,3 +20,21 @@ def scalar_input(func):
         return np.squeeze(func(*args, **kwargs))
 
     return wrapper
+
+
+def immutable(cls):
+    """
+    This marks a class as being immutable, i.e., when doing a copy or a deep copy, we only return self
+    instead of actually making a copy of the class. It should only be used in dataclasses that are marked frozen.
+
+    It works by implementing the __deepcopy__ and __copy__ dunder methods.
+    """
+    def __deepcopy__(self, _):
+        return self
+
+    def __copy__(self):
+        return self
+
+    setattr(cls, '__deepcopy__', __deepcopy__)
+    setattr(cls, '__copy__', __copy__)
+    return cls

--- a/lucupy/minimodel/atom.py
+++ b/lucupy/minimodel/atom.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import FrozenSet
 
@@ -30,9 +30,9 @@ class Atom:
 
     """
     id: int
-    exec_time: timedelta
-    prog_time: timedelta
-    part_time: timedelta
+    exec_time: timedelta = field(hash=False, compare=False)
+    prog_time: timedelta = field(hash=False, compare=False)
+    part_time: timedelta = field(hash=False, compare=False)
     observed: bool
     qa_state: QAState
     guide_state: bool

--- a/lucupy/minimodel/constraints.py
+++ b/lucupy/minimodel/constraints.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum, IntEnum, auto
 from typing import ClassVar, List, Optional, Sequence, Union
@@ -15,6 +15,7 @@ from lucupy.helpers import flatten
 from lucupy.types import ScalarOrNDArray
 
 from .timingwindow import TimingWindow
+from ..decorators import immutable
 
 
 class SkyBackground(float, Enum):
@@ -122,7 +123,8 @@ class ElevationType(IntEnum):
     AIRMASS = auto()
 
 
-@dataclass(order=True, frozen=True)
+@immutable
+@dataclass(frozen=True)
 class Conditions:
     """
     A set of conditions.
@@ -192,7 +194,8 @@ class Conditions:
         return len(self.cc) if isinstance(self.cc, np.ndarray) else 1
 
 
-@dataclass
+@immutable
+@dataclass(frozen=True)
 class Constraints:
     """The constraints required for an observation to be performed.
 
@@ -224,11 +227,12 @@ class Constraints:
     # Default airmass values to use for elevation constraints if:
     # 1. The Constraints are not present in the Observation at all; or
     # 2. The elevation_type is set to NONE.
-    DEFAULT_AIRMASS_ELEVATION_MIN: ClassVar[float] = 1.0
-    DEFAULT_AIRMASS_ELEVATION_MAX: ClassVar[float] = 2.3
+    DEFAULT_AIRMASS_ELEVATION_MIN: ClassVar[float] = field(init=False, default=1.0, repr=False, compare=False)
+    DEFAULT_AIRMASS_ELEVATION_MAX: ClassVar[float] = field(init=False, default=2.3, repr=False, compare=False)
 
 
-@dataclass(order=True, eq=True, frozen=True)
+@immutable
+@dataclass(frozen=True)
 class Variant:
     """A weather variant.
     wind_speed should be in m / s.

--- a/lucupy/minimodel/group.py
+++ b/lucupy/minimodel/group.py
@@ -20,7 +20,7 @@ from ..types import ZeroTime
 ROOT_GROUP_ID: Final[str] = 'root'
 
 
-@dataclass(slots=False)
+@dataclass
 class Group(ABC):
     """This is the base implementation of AND / OR Groups.
     Python does not allow classes to self-reference unless in static contexts,

--- a/lucupy/minimodel/group.py
+++ b/lucupy/minimodel/group.py
@@ -20,7 +20,7 @@ from ..types import ZeroTime
 ROOT_GROUP_ID: Final[str] = 'root'
 
 
-@dataclass
+@dataclass(slots=False)
 class Group(ABC):
     """This is the base implementation of AND / OR Groups.
     Python does not allow classes to self-reference unless in static contexts,
@@ -44,6 +44,8 @@ class Group(ABC):
     number_to_observe: int
     delay_min: timedelta
     delay_max: timedelta
+
+    # Cannot be frozen with gelidum.
     children: Union[List['Group'], Observation]
 
     def __post_init__(self):

--- a/lucupy/minimodel/magnitude.py
+++ b/lucupy/minimodel/magnitude.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Optional
 
+from ..decorators import immutable
+
 
 class MagnitudeSystem(Enum):
     """
@@ -20,6 +22,7 @@ class MagnitudeSystem(Enum):
     JY = auto()
 
 
+@immutable
 @dataclass(frozen=True)
 class MagnitudeBand:
     """They are fully enumerated in MagnitudeBands, so they should be looked up by name there.
@@ -73,6 +76,7 @@ class MagnitudeBands(Enum):
     AP = MagnitudeBand('AP', 0.550, 0.085, description='apparent')
 
 
+@immutable
 @dataclass(frozen=True)
 class Magnitude:
     """A magnitude value in a particular band.

--- a/lucupy/minimodel/observation.py
+++ b/lucupy/minimodel/observation.py
@@ -41,7 +41,6 @@ class ObservationStatus(IntEnum):
     PROPOSED = auto()
     APPROVED = auto()
     FOR_REVIEW = auto()
-    # TODO: Not in original mini-model description, but returned by OCS.
     ON_HOLD = auto()
     READY = auto()
     ONGOING = auto()

--- a/lucupy/minimodel/program.py
+++ b/lucupy/minimodel/program.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum, IntEnum, auto
 from typing import ClassVar, FrozenSet, List, Optional
@@ -12,6 +12,7 @@ from .observation import Observation
 from .semester import Semester
 from .timeallocation import TimeAllocation
 from .too import TooType
+from ..decorators import immutable
 from ..types import ZeroTime
 
 
@@ -37,6 +38,7 @@ class ProgramMode(IntEnum):
     PV = auto()
 
 
+@immutable
 @dataclass(frozen=True)
 class ProgramType:
     """
@@ -90,8 +92,11 @@ class Program:
     type: Optional[ProgramTypes]
     start: datetime
     end: datetime
-    allocated_time: FrozenSet[TimeAllocation]
+    allocated_time: FrozenSet[TimeAllocation] = field(hash=False, compare=False)
+
+    # Root group is immutable and should not be used in hashing or comparisons.
     root_group: AndGroup
+
     too_type: Optional[TooType] = None
 
     FUZZY_BOUNDARY: ClassVar[timedelta] = timedelta(days=14)

--- a/lucupy/minimodel/program.py
+++ b/lucupy/minimodel/program.py
@@ -74,7 +74,7 @@ class ProgramTypes(Enum):
     SV = ProgramType('SV', 'System Verification')
 
 
-@dataclass(unsafe_hash=True)
+@dataclass
 class Program:
     """
     Representation of a program.

--- a/lucupy/minimodel/qastate.py
+++ b/lucupy/minimodel/qastate.py
@@ -26,5 +26,4 @@ class QAState(IntEnum):
     FAIL = auto()
     USABLE = auto()
     PASS = auto()
-    # TODO: Not in original mini-model description, but returned by OCS.
     CHECK = auto()

--- a/lucupy/minimodel/resource.py
+++ b/lucupy/minimodel/resource.py
@@ -4,7 +4,10 @@
 from dataclasses import dataclass
 from typing import Optional
 
+from ..decorators import immutable
 
+
+@immutable
 @dataclass(frozen=True)
 class Resource:
     """This is a general observatory resource.

--- a/lucupy/minimodel/semester.py
+++ b/lucupy/minimodel/semester.py
@@ -6,6 +6,10 @@ from datetime import date
 from enum import Enum
 from typing import Dict, List
 
+from gelidum import freeze
+
+from ..decorators import immutable
+
 
 class SemesterHalf(str, Enum):
     """Gemini typically schedules programs for two semesters per year, namely A and B.
@@ -18,10 +22,10 @@ class SemesterHalf(str, Enum):
     A = 'A'
     B = 'B'
 
-    def start_day(self) -> int:
+    def start_day(self) -> int: # noqa
         return 1
 
-    def end_day(self) -> int:
+    def end_day(self) -> int: # noqa
         return 31
 
     def start_month(self) -> int:
@@ -31,7 +35,7 @@ class SemesterHalf(str, Enum):
         return _semester_half_months[self][-1]
 
     @staticmethod
-    def determine_half(month: int):
+    def determine_half(month: int) -> 'SemesterHalf':
         """
         Given a month, return the SemesterHalf this falls in.
 
@@ -49,13 +53,14 @@ class SemesterHalf(str, Enum):
         raise ValueError(f'Month {month} cannot be found in any SemesterHalf.')
 
 
-# This map actually works. It maps the SemesterHalfs to the months they contain.
-_semester_half_months: Dict[SemesterHalf, List[int]] = {
+# Make a FrozenDict with values FrozenList, so the lists cannot be changed, nor can the dict.
+_semester_half_months: Dict[SemesterHalf, List[int]] = freeze({
     SemesterHalf.A: [2, 3, 4, 5, 6, 7],
     SemesterHalf.B: [8, 9, 10, 11, 12, 1]
-}
+})
 
 
+@immutable
 @dataclass(frozen=True, order=True)
 class Semester:
     """ A semester is a period for which programs may be submitted to Gemini.
@@ -87,7 +92,7 @@ class Semester:
         return date(year=end_year, month=self.half.end_month(), day=self.half.end_day())
 
     @staticmethod
-    def find_semester_from_date(lookup_date: date):
+    def find_semester_from_date(lookup_date: date) -> 'Semester':
         """
         Given a date, return the Semester in which it occurs.
 

--- a/lucupy/minimodel/target.py
+++ b/lucupy/minimodel/target.py
@@ -2,13 +2,14 @@
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 from abc import ABC
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum, IntEnum, auto
 from typing import FrozenSet
 
 import numpy.typing as npt
 
 from .magnitude import Magnitude
+from ..decorators import immutable
 
 TargetName = str
 
@@ -58,7 +59,8 @@ class TargetTag(Enum):
     MAJOR_BODY = auto()
 
 
-@dataclass
+@immutable
+@dataclass(frozen=True)
 class Target(ABC):
     """
     Basic target information.
@@ -79,7 +81,8 @@ class Target(ABC):
         ...
 
 
-@dataclass
+@immutable
+@dataclass(frozen=True)
 class SiderealTarget(Target):
     """
     For a SiderealTarget, we have an RA and Dec and then proper motion information
@@ -106,7 +109,8 @@ class SiderealTarget(Target):
     epoch: float
 
 
-@dataclass
+@immutable
+@dataclass(frozen=True)
 class NonsiderealTarget(Target):
     """
     For a NonsiderealTarget, we have a HORIZONS designation to indicate the lookup

--- a/lucupy/minimodel/timingwindow.py
+++ b/lucupy/minimodel/timingwindow.py
@@ -5,7 +5,10 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import ClassVar, Optional
 
+from ..decorators import immutable
 
+
+@immutable
 @dataclass(frozen=True)
 class TimingWindow:
     """Representation of timing windows in the mini-model.

--- a/lucupy/sky/constants.py
+++ b/lucupy/sky/constants.py
@@ -32,6 +32,8 @@ SPEED_OF_LIGHT: Final[float] = 299792.458  # in km per sec ... exact.
 SS_MASS: Final[float] = 1.00134198  # solar system mass in solar units
 J2000: Final[float] = 2451545.  # Julian date at standard epoch
 J2000_Time: Final[Time] = Time(2451545., format='jd')  # J2000 rendered as a Time
+JYEAR: Final[float] = 365.25 # noqa
+JYEAR_100: Final[float] = JYEAR * 100 # noqa
 SEC_IN_DAY: Final[float] = 86400.
 FLATTEN: Final[float] = 0.003352813  # flattening of earth, 1/298.257
 EQUAT_RAD: Final[Distance] = 6378137. * u.m  # equatorial radius of earth, meters

--- a/lucupy/sky/moon.py
+++ b/lucupy/sky/moon.py
@@ -16,7 +16,7 @@ from astropy.coordinates import (Angle, Distance, EarthLocation,
 from astropy.time import Time, TimeDelta
 
 from .altitude import Altitude
-from .constants import EQUAT_RAD, J2000
+from .constants import EQUAT_RAD, JYEAR, JYEAR_100, J2000
 from .utils import (current_geocent_frame, geocentric_coors,
                     hour_angle_to_angle, local_sidereal_time)
 
@@ -74,7 +74,7 @@ class Moon:
     def _low_precision_calculations(self) -> NoReturn:
         """Compute low precision values for the moon location method calculations.
         """
-        t = (self.time_jd - J2000) / 36525.  # jul cent. since J2000.0
+        t = (self.time_jd - J2000) / JYEAR_100  # jul cent. since J2000.0
 
         lambd = (218.32 + 481267.883 * t
                  + 6.29 * np.sin(np.deg2rad(134.9 + 477198.85 * t))
@@ -100,7 +100,7 @@ class Moon:
     def _high_precision_calculations(self) -> NoReturn:
         """Compute accurate precession values for the moon location method calculations.
         """
-        t = (self.time_ttjd - 2415020.) / 36525.  # this based around 1900 ... */
+        t = (self.time_ttjd - 2415020.) / JYEAR_100  # this based around 1900 ... */
         t_2 = t * t
         t_3 = t_2 * t
         lpr = 270.434164 + 481267.8831 * t - 0.001133 * t_2 + 0.0000019 * t_3
@@ -343,8 +343,8 @@ class Moon:
         # place these in a skycoord in ecliptic coords of date.  Handle distance
         # separately since it does not transform properly for some reason.
 
-        # eq = 'J{:7.2f}'.format(2000. + (time_ttjd[0] - _Constants.J2000) / 365.25)
-        equinox = f'J{2000. + (self.time_ttjd[0] - J2000) / 365.25:7.2f}'
+        # eq = 'J{:7.2f}'.format(2000. + (time_ttjd[0] - _Constants.J2000) / JYEAR)
+        equinox = f'J{2000. + (self.time_ttjd[0] - J2000) / JYEAR:7.2f}'
         frame = GeocentricTrueEcliptic(equinox=equinox)
         inecl = SkyCoord(lon=Angle(self.lambd, unit=u.rad), lat=Angle(self.beta, unit=u.rad), frame=frame)
 

--- a/lucupy/sky/utils.py
+++ b/lucupy/sky/utils.py
@@ -20,7 +20,7 @@ from astropy.units import Quantity
 from pytz import timezone
 
 from .altitude import AngleParam
-from .constants import EQUAT_RAD, FLATTEN, J2000
+from .constants import EQUAT_RAD, FLATTEN, JYEAR, JYEAR_100, J2000
 
 
 def current_geocent_frame(time: Time) -> BaseRADecFrame:
@@ -33,7 +33,7 @@ def current_geocent_frame(time: Time) -> BaseRADecFrame:
         an astropy PrecessedGeocentric time.
     """
     # Generate a PrecessedGeocentric frame for the current equinox.
-    time_ep = 2000. + (np.asarray(time.jd) - J2000) / 365.25
+    time_ep = 2000. + (np.asarray(time.jd) - J2000) / JYEAR
     if time_ep.ndim == 0:
         time_ep = time_ep[None]  # Makes 1D
     equinox = Time(f'J{time_ep[0]:7.2f}')
@@ -196,7 +196,7 @@ def local_sidereal_time(time: Time, location: EarthLocation) -> Angle:
         mid[less_than_half] = julian_int[less_than_half] - 0.5
         ut[less_than_half] = fraction[less_than_half] + 0.5  # as fraction of a day.
 
-    t = (mid - J2000) / 36525.
+    t = (mid - J2000) / JYEAR_100
 
     sidereal = (24110.54841 + 8640184.812866 * t + 0.093104 * t ** 2 - 6.2e-6 * t ** 3) / 86400.
     # at Greenwich

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,17 +21,19 @@ test_all = ["coverage[toml]", "ipython (>=4.2)", "objgraph", "pooch", "pytest (>
 
 [[package]]
 name = "attrs"
-version = "22.1.0"
+version = "22.2.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.extras]
-dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
-docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
-tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+cov = ["attrs[tests]", "coverage-enable-subprocess", "coverage[toml] (>=5.3)"]
+dev = ["attrs[docs,tests]"]
+docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope.interface"]
+tests = ["attrs[tests-no-zope]", "zope.interface"]
+tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=0.971,<0.990)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
+tests_no_zope = ["cloudpickle", "hypothesis", "mypy (>=0.971,<0.990)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 
 [[package]]
 name = "beautifulsoup4"
@@ -153,6 +155,14 @@ docs = ["furo (>=2022.9.29)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.1
 testing = ["covdefaults (>=2.2.2)", "coverage (>=6.5)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-timeout (>=2.1)"]
 
 [[package]]
+name = "gelidum"
+version = "0.5.8"
+description = "Freeze your python objects"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 description = "Copy your docs directly to the gh-pages branch."
@@ -168,7 +178,7 @@ dev = ["flake8", "markdown", "twine", "wheel"]
 
 [[package]]
 name = "griffe"
-version = "0.25.0"
+version = "0.25.1"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 category = "dev"
 optional = false
@@ -219,7 +229,7 @@ zoneinfo = ["backports.zoneinfo (>=0.2.1)", "tzdata (>=2022.1)"]
 
 [[package]]
 name = "identify"
-version = "2.5.9"
+version = "2.5.11"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -496,8 +506,8 @@ setuptools = "*"
 
 [[package]]
 name = "numpy"
-version = "1.23.5"
-description = "NumPy is the fundamental package for array computing with Python."
+version = "1.24.0"
+description = "Fundamental package for array computing in Python"
 category = "main"
 optional = false
 python-versions = ">=3.8"
@@ -658,7 +668,7 @@ six = ">=1.5"
 
 [[package]]
 name = "pytz"
-version = "2022.6"
+version = "2022.7"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
@@ -809,7 +819,7 @@ bracex = ">=2.1.1"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "bd1719d37693bff003d74e00fbfe4173886ca317848e2126e30ca7bd6a3b6e83"
+content-hash = "a94e502b66ebf80bc9c4ed5f18235e601c6a0db6ea7151363cc17b7cd122cd48"
 
 [metadata.files]
 astropy = [
@@ -846,8 +856,8 @@ astropy = [
     {file = "astropy-5.2.tar.gz", hash = "sha256:d335604025f6e16f7c9bf82d5ba28e5db4745a82e5823a9d17bdd9b9bd46b2a2"},
 ]
 attrs = [
-    {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
-    {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
+    {file = "attrs-22.2.0-py3-none-any.whl", hash = "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836"},
+    {file = "attrs-22.2.0.tar.gz", hash = "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"},
 ]
 beautifulsoup4 = [
     {file = "beautifulsoup4-4.11.1-py3-none-any.whl", hash = "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30"},
@@ -896,13 +906,16 @@ filelock = [
     {file = "filelock-3.8.2-py3-none-any.whl", hash = "sha256:8df285554452285f79c035efb0c861eb33a4bcfa5b7a137016e32e6a90f9792c"},
     {file = "filelock-3.8.2.tar.gz", hash = "sha256:7565f628ea56bfcd8e54e42bdc55da899c85c1abfe1b5bcfd147e9188cebb3b2"},
 ]
+gelidum = [
+    {file = "gelidum-0.5.8.tar.gz", hash = "sha256:6b56139b4439d9739287a4eb19495d920244c41523e35a4af570b25903bd1e3c"},
+]
 ghp-import = [
     {file = "ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343"},
     {file = "ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619"},
 ]
 griffe = [
-    {file = "griffe-0.25.0-py3-none-any.whl", hash = "sha256:57527250e06c0fac5381c5ccc9695b6c46a3af51928d99364bf2e5fd9aabf37d"},
-    {file = "griffe-0.25.0.tar.gz", hash = "sha256:35d412d2235330a05c755f906458c70ee8a4eec85bc3de20f1fd79d0a501dc38"},
+    {file = "griffe-0.25.1-py3-none-any.whl", hash = "sha256:a2d6cef8129579438c3e71401a5fb035ffea5afa8f8e27d946dbb9e136b90b1a"},
+    {file = "griffe-0.25.1.tar.gz", hash = "sha256:d79365aa6f5050a24b47fca4b351fbdd446f0fe7924c9e55ae908bfacc91bfcf"},
 ]
 htmlmin = [
     {file = "htmlmin-0.1.12.tar.gz", hash = "sha256:50c1ef4630374a5d723900096a961cff426dff46b48f34d194a81bbe14eca178"},
@@ -912,8 +925,8 @@ hypothesis = [
     {file = "hypothesis-6.54.2.tar.gz", hash = "sha256:db40e3f296ab940e59e5bbb1794e5b2f9682b601c559b3f68fc294518ba6cff7"},
 ]
 identify = [
-    {file = "identify-2.5.9-py2.py3-none-any.whl", hash = "sha256:a390fb696e164dbddb047a0db26e57972ae52fbd037ae68797e5ae2f4492485d"},
-    {file = "identify-2.5.9.tar.gz", hash = "sha256:906036344ca769539610436e40a684e170c3648b552194980bb7b617a8daeb9f"},
+    {file = "identify-2.5.11-py2.py3-none-any.whl", hash = "sha256:e7db36b772b188099616aaf2accbee122949d1c6a1bac4f38196720d6f9f06db"},
+    {file = "identify-2.5.11.tar.gz", hash = "sha256:14b7076b29c99b1b0b8b08e96d448c7b877a9b07683cd8cfda2ea06af85ffa1c"},
 ]
 idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
@@ -1040,34 +1053,34 @@ nodeenv = [
     {file = "nodeenv-1.7.0.tar.gz", hash = "sha256:e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b"},
 ]
 numpy = [
-    {file = "numpy-1.23.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9c88793f78fca17da0145455f0d7826bcb9f37da4764af27ac945488116efe63"},
-    {file = "numpy-1.23.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e9f4c4e51567b616be64e05d517c79a8a22f3606499941d97bb76f2ca59f982d"},
-    {file = "numpy-1.23.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7903ba8ab592b82014713c491f6c5d3a1cde5b4a3bf116404e08f5b52f6daf43"},
-    {file = "numpy-1.23.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e05b1c973a9f858c74367553e236f287e749465f773328c8ef31abe18f691e1"},
-    {file = "numpy-1.23.5-cp310-cp310-win32.whl", hash = "sha256:522e26bbf6377e4d76403826ed689c295b0b238f46c28a7251ab94716da0b280"},
-    {file = "numpy-1.23.5-cp310-cp310-win_amd64.whl", hash = "sha256:dbee87b469018961d1ad79b1a5d50c0ae850000b639bcb1b694e9981083243b6"},
-    {file = "numpy-1.23.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ce571367b6dfe60af04e04a1834ca2dc5f46004ac1cc756fb95319f64c095a96"},
-    {file = "numpy-1.23.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:56e454c7833e94ec9769fa0f86e6ff8e42ee38ce0ce1fa4cbb747ea7e06d56aa"},
-    {file = "numpy-1.23.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5039f55555e1eab31124a5768898c9e22c25a65c1e0037f4d7c495a45778c9f2"},
-    {file = "numpy-1.23.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58f545efd1108e647604a1b5aa809591ccd2540f468a880bedb97247e72db387"},
-    {file = "numpy-1.23.5-cp311-cp311-win32.whl", hash = "sha256:b2a9ab7c279c91974f756c84c365a669a887efa287365a8e2c418f8b3ba73fb0"},
-    {file = "numpy-1.23.5-cp311-cp311-win_amd64.whl", hash = "sha256:0cbe9848fad08baf71de1a39e12d1b6310f1d5b2d0ea4de051058e6e1076852d"},
-    {file = "numpy-1.23.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f063b69b090c9d918f9df0a12116029e274daf0181df392839661c4c7ec9018a"},
-    {file = "numpy-1.23.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0aaee12d8883552fadfc41e96b4c82ee7d794949e2a7c3b3a7201e968c7ecab9"},
-    {file = "numpy-1.23.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:92c8c1e89a1f5028a4c6d9e3ccbe311b6ba53694811269b992c0b224269e2398"},
-    {file = "numpy-1.23.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d208a0f8729f3fb790ed18a003f3a57895b989b40ea4dce4717e9cf4af62c6bb"},
-    {file = "numpy-1.23.5-cp38-cp38-win32.whl", hash = "sha256:06005a2ef6014e9956c09ba07654f9837d9e26696a0470e42beedadb78c11b07"},
-    {file = "numpy-1.23.5-cp38-cp38-win_amd64.whl", hash = "sha256:ca51fcfcc5f9354c45f400059e88bc09215fb71a48d3768fb80e357f3b457e1e"},
-    {file = "numpy-1.23.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8969bfd28e85c81f3f94eb4a66bc2cf1dbdc5c18efc320af34bffc54d6b1e38f"},
-    {file = "numpy-1.23.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a7ac231a08bb37f852849bbb387a20a57574a97cfc7b6cabb488a4fc8be176de"},
-    {file = "numpy-1.23.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf837dc63ba5c06dc8797c398db1e223a466c7ece27a1f7b5232ba3466aafe3d"},
-    {file = "numpy-1.23.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33161613d2269025873025b33e879825ec7b1d831317e68f4f2f0f84ed14c719"},
-    {file = "numpy-1.23.5-cp39-cp39-win32.whl", hash = "sha256:af1da88f6bc3d2338ebbf0e22fe487821ea4d8e89053e25fa59d1d79786e7481"},
-    {file = "numpy-1.23.5-cp39-cp39-win_amd64.whl", hash = "sha256:09b7847f7e83ca37c6e627682f145856de331049013853f344f37b0c9690e3df"},
-    {file = "numpy-1.23.5-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:abdde9f795cf292fb9651ed48185503a2ff29be87770c3b8e2a14b0cd7aa16f8"},
-    {file = "numpy-1.23.5-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9a909a8bae284d46bbfdefbdd4a262ba19d3bc9921b1e76126b1d21c3c34135"},
-    {file = "numpy-1.23.5-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:01dd17cbb340bf0fc23981e52e1d18a9d4050792e8fb8363cecbf066a84b827d"},
-    {file = "numpy-1.23.5.tar.gz", hash = "sha256:1b1766d6f397c18153d40015ddfc79ddb715cabadc04d2d228d4e5a8bc4ded1a"},
+    {file = "numpy-1.24.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6e73a1f4f5b74a42abb55bc2b3d869f1b38cbc8776da5f8b66bf110284f7a437"},
+    {file = "numpy-1.24.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9387c7d6d50e8f8c31e7bfc034241e9c6f4b3eb5db8d118d6487047b922f82af"},
+    {file = "numpy-1.24.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ad6a024a32ee61d18f5b402cd02e9c0e22c0fb9dc23751991b3a16d209d972e"},
+    {file = "numpy-1.24.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:73cf2c5b5a07450f20a0c8e04d9955491970177dce8df8d6903bf253e53268e0"},
+    {file = "numpy-1.24.0-cp310-cp310-win32.whl", hash = "sha256:cec79ff3984b2d1d103183fc4a3361f5b55bbb66cb395cbf5a920a4bb1fd588d"},
+    {file = "numpy-1.24.0-cp310-cp310-win_amd64.whl", hash = "sha256:4f5e78b8b710cd7cd1a8145994cfffc6ddd5911669a437777d8cedfce6c83a98"},
+    {file = "numpy-1.24.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4445f472b246cad6514cc09fbb5ecb7aab09ca2acc3c16f29f8dca6c468af501"},
+    {file = "numpy-1.24.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ec3e5e8172a0a6a4f3c2e7423d4a8434c41349141b04744b11a90e017a95bad5"},
+    {file = "numpy-1.24.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9168790149f917ad8e3cf5047b353fefef753bd50b07c547da0bdf30bc15d91"},
+    {file = "numpy-1.24.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ada6c1e9608ceadaf7020e1deea508b73ace85560a16f51bef26aecb93626a72"},
+    {file = "numpy-1.24.0-cp311-cp311-win32.whl", hash = "sha256:f3c4a9a9f92734a4728ddbd331e0124eabbc968a0359a506e8e74a9b0d2d419b"},
+    {file = "numpy-1.24.0-cp311-cp311-win_amd64.whl", hash = "sha256:90075ef2c6ac6397d0035bcd8b298b26e481a7035f7a3f382c047eb9c3414db0"},
+    {file = "numpy-1.24.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0885d9a7666cafe5f9876c57bfee34226e2b2847bfb94c9505e18d81011e5401"},
+    {file = "numpy-1.24.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e63d2157f9fc98cc178870db83b0e0c85acdadd598b134b00ebec9e0db57a01f"},
+    {file = "numpy-1.24.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf8960f72997e56781eb1c2ea256a70124f92a543b384f89e5fb3503a308b1d3"},
+    {file = "numpy-1.24.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2f8e0df2ecc1928ef7256f18e309c9d6229b08b5be859163f5caa59c93d53646"},
+    {file = "numpy-1.24.0-cp38-cp38-win32.whl", hash = "sha256:fe44e925c68fb5e8db1334bf30ac1a1b6b963b932a19cf41d2e899cf02f36aab"},
+    {file = "numpy-1.24.0-cp38-cp38-win_amd64.whl", hash = "sha256:d7f223554aba7280e6057727333ed357b71b7da7422d02ff5e91b857888c25d1"},
+    {file = "numpy-1.24.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ab11f6a7602cf8ea4c093e091938207de3068c5693a0520168ecf4395750f7ea"},
+    {file = "numpy-1.24.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:12bba5561d8118981f2f1ff069ecae200c05d7b6c78a5cdac0911f74bc71cbd1"},
+    {file = "numpy-1.24.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9af91f794d2d3007d91d749ebc955302889261db514eb24caef30e03e8ec1e41"},
+    {file = "numpy-1.24.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b1ddfac6a82d4f3c8e99436c90b9c2c68c0bb14658d1684cdd00f05fab241f5"},
+    {file = "numpy-1.24.0-cp39-cp39-win32.whl", hash = "sha256:ac4fe68f1a5a18136acebd4eff91aab8bed00d1ef2fdb34b5d9192297ffbbdfc"},
+    {file = "numpy-1.24.0-cp39-cp39-win_amd64.whl", hash = "sha256:667b5b1f6a352419e340f6475ef9930348ae5cb7fca15f2cc3afcb530823715e"},
+    {file = "numpy-1.24.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:4d01f7832fa319a36fd75ba10ea4027c9338ede875792f7bf617f4b45056fc3a"},
+    {file = "numpy-1.24.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dbb0490f0a880700a6cc4d000384baf19c1f4df59fff158d9482d4dbbca2b239"},
+    {file = "numpy-1.24.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:0104d8adaa3a4cc60c2777cab5196593bf8a7f416eda133be1f3803dd0838886"},
+    {file = "numpy-1.24.0.tar.gz", hash = "sha256:c4ab7c9711fe6b235e86487ca74c1b092a6dd59a3cb45b63241ea0a148501853"},
 ]
 packaging = [
     {file = "packaging-22.0-py3-none-any.whl", hash = "sha256:957e2148ba0e1a3b282772e791ef1d8083648bc131c8ab0c1feba110ce1146c3"},
@@ -1145,8 +1158,8 @@ python-dateutil = [
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
 pytz = [
-    {file = "pytz-2022.6-py2.py3-none-any.whl", hash = "sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427"},
-    {file = "pytz-2022.6.tar.gz", hash = "sha256:e89512406b793ca39f5971bc999cc538ce125c0e51c27941bef4568b460095e2"},
+    {file = "pytz-2022.7-py2.py3-none-any.whl", hash = "sha256:93007def75ae22f7cd991c84e02d434876818661f8df9ad5df9e950ff4e52cfd"},
+    {file = "pytz-2022.7.tar.gz", hash = "sha256:7ccfae7b4b2c067464a6733c6261673fdb8fd1be905460396b97a073e9fa683a"},
 ]
 PyYAML = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.19"
+version = "0.1.20"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = ["Sergio Troncoso <sergio.troncoso@noirlab.edu>",
            "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ mkdocstrings = {extras = ["python"], version = "^0.19.0"}
 [tool.poetry.dependencies]
 python = "^3.10"
 astropy = "^5.1"
-pytz = "^2022.2"
+pytz = "^2022.7"
+gelidum = "^0.5.8"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.2"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -29,7 +29,7 @@ def observation():
         targets=[],
         guiding={},
         sequence=[],
-        constraints=None,
+        constraints=None
     )
 
 

--- a/tests/test_immutable.py
+++ b/tests/test_immutable.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+# For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+from datetime import datetime, timedelta
+
+from lucupy.minimodel import (AndGroup, AndOption, Band, CloudCover, Conditions, Constraints, ElevationType, ImageQuality, Magnitude, MagnitudeBands, Observation, ObservationClass, ObservationStatus, Priority, Program, ProgramMode, ProgramTypes, ROOT_GROUP_ID, SetupTimeType, Semester, SemesterHalf, SiderealTarget, Site, SkyBackground, TargetType, TimeAccountingCode, TimeAllocation, TimingWindow, WaterVapor)
+
+
+def test_deepcopy():
+    m1 = Magnitude(band=MagnitudeBands.R,
+                   value=1.)
+    m2 = Magnitude(band=MagnitudeBands.B,
+                   value=2.)
+
+    t = SiderealTarget(name='t',
+                       magnitudes=frozenset({m1, m2}),
+                       type=TargetType.BASE,
+                       ra=0.,
+                       dec=0.,
+                       pm_ra=1.,
+                       pm_dec=-1.,
+                       epoch=2000.)
+
+    conditions = Conditions(cc=CloudCover.CC50,
+                            iq=ImageQuality.IQ20,
+                            sb=SkyBackground.SB50,
+                            wv=WaterVapor.WVANY)
+
+    tw = TimingWindow(start=datetime(year=2022, month=12, day=21, hour=0, minute=5, second=30),
+                      duration=TimingWindow.INFINITE_DURATION,
+                      repeat=TimingWindow.NON_REPEATING,
+                      period=TimingWindow.NO_PERIOD)
+
+    c = Constraints(conditions=conditions,
+                    elevation_type=ElevationType.AIRMASS,
+                    elevation_min=Constraints.DEFAULT_AIRMASS_ELEVATION_MIN,
+                    elevation_max=Constraints.DEFAULT_AIRMASS_ELEVATION_MAX,
+                    timing_windows=[tw])
+
+    o = Observation(id='o1',
+                    internal_id='3829381',
+                    order=0,
+                    title='Observation 1',
+                    site=Site.GN,
+                    status=ObservationStatus.READY,
+                    active=True,
+                    priority=Priority.MEDIUM,
+                    setuptime_type=SetupTimeType.REACQUISITION,
+                    acq_overhead=timedelta(minutes=10),
+                    obs_class=ObservationClass.SCIENCE,
+                    targets=[t],
+                    guiding={},
+                    sequence=[],
+                    constraints=c)
+
+    gp = AndGroup(id='g1',
+                  program_id='p1',
+                  group_name='Group 1',
+                  number_to_observe=1,
+                  delay_min=timedelta(),
+                  delay_max=timedelta(),
+                  children=o,
+                  group_option=AndOption.ANYORDER)
+
+    root = AndGroup(id=ROOT_GROUP_ID,
+                    program_id='p1',
+                    group_name=ROOT_GROUP_ID,
+                    number_to_observe=1,
+                    delay_min=timedelta(),
+                    delay_max=timedelta(),
+                    children=[gp],
+                    group_option=AndOption.ANYORDER)
+
+    s = Semester(year=2022,
+                 half=SemesterHalf.B)
+
+    ta = TimeAllocation(category=TimeAccountingCode.KR,
+                        program_awarded=timedelta(hours=2),
+                        partner_awarded=timedelta(minutes=30),
+                        program_used=timedelta(minutes=30),
+                        partner_used=timedelta())
+
+    p = Program(id='p1',
+                internal_id='223e2332',
+                semester=s,
+                band=Band.BAND2,
+                thesis=False,
+                mode=ProgramMode.QUEUE,
+                type=ProgramTypes.Q,
+                start=datetime.now(),
+                end=datetime.now(),
+                allocated_time=frozenset({ta}),
+                root_group=root)

--- a/tests/test_immutable.py
+++ b/tests/test_immutable.py
@@ -1,12 +1,17 @@
 # Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
+from copy import deepcopy
 from datetime import datetime, timedelta
 
-from lucupy.minimodel import (AndGroup, AndOption, Band, CloudCover, Conditions, Constraints, ElevationType, ImageQuality, Magnitude, MagnitudeBands, Observation, ObservationClass, ObservationStatus, Priority, Program, ProgramMode, ProgramTypes, ROOT_GROUP_ID, SetupTimeType, Semester, SemesterHalf, SiderealTarget, Site, SkyBackground, TargetType, TimeAccountingCode, TimeAllocation, TimingWindow, WaterVapor)
+from lucupy.minimodel import (AndGroup, AndOption, Band, CloudCover, Conditions, Constraints, ElevationType,
+                              ImageQuality, Magnitude, MagnitudeBands, Observation, ObservationClass,
+                              ObservationStatus, Priority, Program, ProgramMode, ProgramTypes, ROOT_GROUP_ID,
+                              SetupTimeType, Semester, SemesterHalf, SiderealTarget, Site, SkyBackground, TargetType,
+                              TimeAccountingCode, TimeAllocation, TimingWindow, WaterVapor)
 
 
-def test_deepcopy():
+def test_immutable_deepcopy():
     m1 = Magnitude(band=MagnitudeBands.R,
                    value=1.)
     m2 = Magnitude(band=MagnitudeBands.B,
@@ -91,3 +96,32 @@ def test_deepcopy():
                 end=datetime.now(),
                 allocated_time=frozenset({ta}),
                 root_group=root)
+
+    p2 = deepcopy(p)
+
+    # Program should not be the same.
+    assert p is not p2
+
+    # Semester should be the same.
+    assert p.semester is p2.semester
+
+    # Time Allocation should not be the same.
+    assert p.allocated_time is not p2.allocated_time
+
+    # Root group should not be the same.
+    root2 = p2.root_group
+    assert root is not root2
+
+    # Child group should not be the same.
+    gp2 = root2.children[0]
+    assert gp is not gp2
+
+    # Observation should not be the same.
+    o2 = gp2.children
+    assert o is not o2
+
+    # Constraints should be the same. This will implicitly test timing windows as well.
+    assert o.constraints is o2.constraints
+
+    # Targets should be the same. This will implicitly test magnitudes as well.
+    assert o.targets[0] is o2.targets[0]


### PR DESCRIPTION
In this PR:
* I added an `immutable` decorator, which redirects `copy` and `deepcopy` to return `self` instead of an actual copy of self.
* I cleaned up some dataclasses, to avoid using mutable members in hashing and removing all unsafe hashing, and marking members with `field` options to improve the code.
* Added gelidum library to freeze data structures that should be truly immutable (i.e. freezing lists and dicts instead of just their assigned references).
* Removed warnings with `# noqa` tag.
* Added a test case to test the `immutable` decorator and the results of `deepcopy`ing a `Program`.