### PR TITLE
Update partner/program times in atoms

### DIFF
--- a/lucupy/minimodel/atom.py
+++ b/lucupy/minimodel/atom.py
@@ -19,9 +19,11 @@ class Atom:
     Attributes:
 
         id (int): GPP atom `id`. In other case is given by the Provider
-        exec_time (timedelta): Total time of execution.
-        prog_time (timedelta): Program time.
-        part_time (timedelta): Partner time.
+        exec_time (timedelta): Total planned time of execution.
+        prog_time (timedelta): Planned program time.
+        part_time (timedelta): Planned partner time.
+        program_used (timedelta): Used (charged) program time.
+        partner_used (timedelta): Used (charged) partner time.
         observed (bool): True if the STATUS is already observed.
         qa_state (QAState):
         guide_state (bool): True if a state exists.
@@ -33,6 +35,8 @@ class Atom:
     exec_time: timedelta = field(hash=False, compare=False)
     prog_time: timedelta = field(hash=False, compare=False)
     part_time: timedelta = field(hash=False, compare=False)
+    program_used: timedelta = field(hash=False, compare=False)
+    partner_used: timedelta = field(hash=False, compare=False)
     observed: bool
     qa_state: QAState
     guide_state: bool

--- a/lucupy/minimodel/observation.py
+++ b/lucupy/minimodel/observation.py
@@ -234,7 +234,7 @@ class Observation:
         Returns:
             (timedelta): With the time program used.
         """
-        return sum((atom.prog_time for atom in self.sequence), start=ZeroTime)
+        return sum((atom.program_used for atom in self.sequence), start=ZeroTime)
 
     def partner_used(self) -> timedelta:
         """We roll this information up from the atoms as it will be calculated
@@ -244,12 +244,12 @@ class Observation:
         Returns:
             (timedelta): With the time program used.
         """
-        return sum((atom.part_time for atom in self.sequence), start=ZeroTime)
+        return sum((atom.partner_used for atom in self.sequence), start=ZeroTime)
 
     @staticmethod
     def _select_obsclass(classes: List[ObservationClass]) -> Optional[ObservationClass]:
         """Given a list of non-empty ObservationClasses, determine which occurs with
-        highest precedence in the ObservationClasses enum, i.e. has the lowest index.
+        the highest precedence in the ObservationClasses enum, i.e. has the lowest index.
 
         This will be used when examining the sequence for atoms.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.33"
+version = "0.1.34"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = ["Sergio Troncoso <sergio.troncoso@noirlab.edu>",
            "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",


### PR DESCRIPTION
Add partner_used and program_used attributes to the atom class and update observation methods to use these. These are needed for the greedymax internal time accounting.
Also, rebased with the latest program/group/observation id changes.