### PR TITLE
SCHED-393: Enum linear interpolation.

### DIFF
--- a/lucupy/helpers/__init__.py
+++ b/lucupy/helpers/__init__.py
@@ -231,18 +231,4 @@ def lerp_enum(enum_class: Type[Enum], first_value: float, last_value: float, n: 
         result = [sorted_values[bisect.bisect_right(sorted_values, x) - 1] for x in interp_values]
     else:
         result = [sorted_values[bisect.bisect_left(sorted_values, x) - 1] for x in interp_values]
-    # if first_value <= last_value:
-    #     result = [min(sorted_values, key=lambda x: x - value) for value in interp_values]
-    # else:
-    #     result = [min(sorted_values, key=lambda x: value - x) for value in interp_values]
     return np.array(result)
-
-
-if __name__ == '__main__':
-    from lucupy.minimodel import CloudCover
-    print(lerp_enum(CloudCover, 0.5, 1.0, 5))
-    print(lerp_enum(CloudCover, 0.5, 1.0, 6))
-    print(lerp_enum(CloudCover, 1.0, 0.5, 5))
-    print(lerp_enum(CloudCover, 1.0, 0.5, 6))
-    print(lerp_enum(CloudCover, 0.5, 1.0, 1))
-    print(lerp_enum(CloudCover, 1.0, 0.5, 1))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+# For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+import pytest
+import numpy as np
+
+from lucupy.minimodel import CloudCover
+from lucupy.helpers import lerp_enum
+
+
+@pytest.mark.parametrize('first_value, last_value, n, expected',
+                         [(0.5, 1.0, 5, np.array([0.5, 0.5, 0.7, 0.8, 0.8])),
+                          (0.5, 1.0, 6, np.array([0.5, 0.5, 0.7, 0.7, 0.8, 0.8])),
+                          (1.0, 0.5, 5, np.array([0.8, 0.8, 0.7, 0.5, 0.5])),
+                          (1.0, 0.5, 6, np.array([0.8, 0.8, 0.7, 0.7, 0.5, 0.5])),
+                          (0.5, 1.0, 1, np.array([0.7])),
+                          (1.0, 0.5, 1, np.array([0.7]))])
+def test_lerp_enum(first_value, last_value, n, expected):
+    assert np.array_equal(lerp_enum(CloudCover, first_value, last_value, n), expected)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -14,6 +14,7 @@ from lucupy.helpers import lerp_enum
                           (1.0, 0.5, 5, np.array([0.8, 0.8, 0.7, 0.5, 0.5])),
                           (1.0, 0.5, 6, np.array([0.8, 0.8, 0.7, 0.7, 0.5, 0.5])),
                           (0.5, 1.0, 1, np.array([0.7])),
-                          (1.0, 0.5, 1, np.array([0.7]))])
+                          (1.0, 0.5, 1, np.array([0.7])),
+                          (0.7, 0.7, 3, np.array([0.7, 0.7, 0.7]))])
 def test_lerp_enum(first_value, last_value, n, expected):
     assert np.array_equal(lerp_enum(CloudCover, first_value, last_value, n), expected)


### PR DESCRIPTION
Linear Interpolation between two values in an Enum with a certain number of steps.
This was recommended by Fredrik as the way we should be filling in missing weather data instead of using the `ffill()` pandas functionality that we are using now.