### PR TITLE
SCHED-393: Fixing enum lerp.

### DIFF
--- a/lucupy/helpers/__init__.py
+++ b/lucupy/helpers/__init__.py
@@ -228,7 +228,7 @@ def lerp_enum(enum_class: Type[Enum], first_value: float, last_value: float, n: 
 
     # Interpolate over the Enum.
     if first_value <= last_value:
-        result = [sorted_values[bisect.bisect_right(sorted_values, x) - 1] for x in interp_values]
+        result = [sorted_values[bisect.bisect_left(sorted_values, x)] for x in interp_values]
     else:
-        result = [sorted_values[bisect.bisect_left(sorted_values, x) - 1] for x in interp_values]
+        result = [sorted_values[bisect.bisect_right(sorted_values, x)] for x in interp_values]
     return np.array(result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.36"
+version = "0.1.37"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = ["Sergio Troncoso <sergio.troncoso@noirlab.edu>",
            "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -9,12 +9,12 @@ from lucupy.helpers import lerp_enum
 
 
 @pytest.mark.parametrize('first_value, last_value, n, expected',
-                         [(0.5, 1.0, 5, np.array([0.5, 0.5, 0.7, 0.8, 0.8])),
-                          (0.5, 1.0, 6, np.array([0.5, 0.5, 0.7, 0.7, 0.8, 0.8])),
-                          (1.0, 0.5, 5, np.array([0.8, 0.8, 0.7, 0.5, 0.5])),
-                          (1.0, 0.5, 6, np.array([0.8, 0.8, 0.7, 0.7, 0.5, 0.5])),
-                          (0.5, 1.0, 1, np.array([0.7])),
-                          (1.0, 0.5, 1, np.array([0.7])),
+                         [(0.5, 1.0, 5, np.array([0.7, 0.7, 0.8, 1.0, 1.0])),
+                          (0.5, 1.0, 6, np.array([0.7, 0.7, 0.8, 0.8, 1.0, 1.0])),
+                          (1.0, 0.5, 5, np.array([1.0, 1.0, 0.8, 0.7, 0.7])),
+                          (1.0, 0.5, 6, np.array([1.0, 1.0, 0.8, 0.8, 0.7, 0.7])),
+                          (0.5, 1.0, 1, np.array([0.8])),
+                          (1.0, 0.5, 1, np.array([0.8])),
                           (0.7, 0.7, 3, np.array([0.7, 0.7, 0.7]))])
 def test_lerp_enum(first_value, last_value, n, expected):
     assert np.array_equal(lerp_enum(CloudCover, first_value, last_value, n), expected)


### PR DESCRIPTION
Before, when we linearly interpreted between the values of an `Enum`, we chose the floor value, which is not what we wanted We want to clamp values to the value above the linearly interpolated value, as in the case in something like `CloudCover`, a 0.54 should, for example, be interpreted as a `0.7` and not a `0.5`.