### PR TITLE
SCHED-398: Added lerp_radians for wind_dir and improved test cases.

### DIFF
--- a/lucupy/helpers/__init__.py
+++ b/lucupy/helpers/__init__.py
@@ -205,6 +205,13 @@ def angular_distance(ra1: float, dec1: float, ra2: float, dec2: float) -> float:
     return 2 * np.arctan2(np.sqrt(a), np.sqrt(1 - a))
 
 
+def lerp(start_value: float, end_value: float, n: int) -> npt.NDArray[float]:
+    """
+    Perform a linear interpolation for n points between start_value and end_value.
+    """
+    return np.linspace(start_value, end_value, n + 2)[1:-1]
+
+
 def lerp_enum(enum_class: Type[Enum], first_value: float, last_value: float, n: int) -> npt.NDArray[float]:
     """
     Given an Enum of float, a first_value, a last_value, and a number of slots, interpolate over the Enum
@@ -232,3 +239,25 @@ def lerp_enum(enum_class: Type[Enum], first_value: float, last_value: float, n: 
     else:
         result = [sorted_values[bisect.bisect_right(sorted_values, x)] for x in interp_values]
     return np.array(result)
+
+
+def lerp_radians(start_value: float, end_value: float, n: int) -> npt.NDArray[float]:
+    """
+    Perform a linear interpolation for n points between start_value radians and end_value radians.
+    """
+    # Normalize start and end values to the range [0, 2pi]
+    start_value = start_value % (2 * np.pi)
+    end_value = end_value % (2 * np.pi)
+
+    # Calculate distances
+    direct_clockwise_distance = (end_value - start_value) % (2 * np.pi)
+    direct_counterclockwise_distance = (start_value - end_value) % (2 * np.pi)
+
+    # Choose the direction with the shortest distance
+    if direct_clockwise_distance < direct_counterclockwise_distance:
+        shortest_distance = direct_clockwise_distance
+    else:
+        shortest_distance = -direct_counterclockwise_distance
+
+    # Generate the lerp.
+    return (start_value + shortest_distance * lerp(0, 1, n)) % (2 * np.pi)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.37"
+version = "0.1.38"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = ["Sergio Troncoso <sergio.troncoso@noirlab.edu>",
            "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,7 +5,14 @@ import pytest
 import numpy as np
 
 from lucupy.minimodel import CloudCover
-from lucupy.helpers import lerp_enum
+from lucupy.helpers import lerp, lerp_enum, lerp_radians
+
+
+@pytest.mark.parametrize('first_value, last_value, n, expected',
+                         [(0, 11, 10, np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])),
+                          (0, 0, 10, np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))])
+def test_lerp(first_value, last_value, n, expected):
+    assert np.allclose(lerp(first_value, last_value, n), expected)
 
 
 @pytest.mark.parametrize('first_value, last_value, n, expected',
@@ -17,4 +24,15 @@ from lucupy.helpers import lerp_enum
                           (1.0, 0.5, 1, np.array([0.8])),
                           (0.7, 0.7, 3, np.array([0.7, 0.7, 0.7]))])
 def test_lerp_enum(first_value, last_value, n, expected):
-    assert np.array_equal(lerp_enum(CloudCover, first_value, last_value, n), expected)
+    assert np.allclose(lerp_enum(CloudCover, first_value, last_value, n), expected)
+
+
+@pytest.mark.parametrize('first_value, last_value, n, expected',
+                         [(np.pi/2, 3*np.pi/2, 4, np.array([0.9424778, 0.31415927, 5.96902604, 5.34070751])),
+                          (np.pi/2, -np.pi/2, 4, np.array([0.9424778, 0.31415927, 5.96902604, 5.34070751])),
+                          (np.pi/2 + 1e3, 3*np.pi/2, 4, np.array([2.97794378, 3.41155508, 3.84516638, 4.27877768])),
+                          (np.pi/2 + 1e3, -np.pi/2, 4, np.array([2.97794378, 3.41155508, 3.84516638, 4.27877768])),
+                          (np.pi/4, -np.pi/4, 3, np.array([0.39269908, 0, 5.89048623])),
+                          (-np.pi/4, np.pi/4, 3, np.array([5.89048623, 0, 0.39269908]))])
+def test_lerp_radians(first_value, last_value, n, expected):
+    assert np.allclose(lerp_radians(first_value, last_value, n), expected)


### PR DESCRIPTION
`lerp_radians` takes the smallest angle between `start_value` and `end_value` and linearly interpolates between them.

The interpolation between antipodal points is, understandably, unpredictable. For example:
1. Interpolation between `π/2` and `-π/2` (or equivalently `3π/2`) is done clockwise; whereas
2. Interpolation between `-π/2` (or equivalently `3π/2`) and `π/2` is done counterclockwise.

Thus, `lerp_radians(np.pi/2, -np.pi/2) == lerp_radians(-np.pi/2, np.pi/2)[::-1]`.
A small epsilon added to a parameter can flip the interpolation if necessary.

The test cases have been improved to use `np.allclose` to handle floating point errors.