### PR TITLE
SCHED-398C: lerp_degrees

### DIFF
--- a/lucupy/helpers/__init__.py
+++ b/lucupy/helpers/__init__.py
@@ -241,17 +241,19 @@ def lerp_enum(enum_class: Type[Enum], first_value: float, last_value: float, n: 
     return np.array(result)
 
 
-def lerp_radians(start_value: float, end_value: float, n: int) -> npt.NDArray[float]:
+def _lerp_circular(start_value: float, end_value: float, n: int, max_val: float) -> npt.NDArray[float]:
     """
-    Perform a linear interpolation for n points between start_value radians and end_value radians.
+    Perform a linear interpolation for n points between start_value and end_value.
+    For degrees, max_val should be 360.
+    For radians, max_val should be 2pi.
     """
-    # Normalize start and end values to the range [0, 2pi]
-    start_value = start_value % (2 * np.pi)
-    end_value = end_value % (2 * np.pi)
+    # Normalize start and end values to the range [0, max_val)
+    start_value %= max_val
+    end_value %= max_val
 
     # Calculate distances
-    direct_clockwise_distance = (end_value - start_value) % (2 * np.pi)
-    direct_counterclockwise_distance = (start_value - end_value) % (2 * np.pi)
+    direct_clockwise_distance = (end_value - start_value) % max_val
+    direct_counterclockwise_distance = (start_value - end_value) % max_val
 
     # Choose the direction with the shortest distance
     if direct_clockwise_distance < direct_counterclockwise_distance:
@@ -260,4 +262,12 @@ def lerp_radians(start_value: float, end_value: float, n: int) -> npt.NDArray[fl
         shortest_distance = -direct_counterclockwise_distance
 
     # Generate the lerp.
-    return (start_value + shortest_distance * lerp(0, 1, n)) % (2 * np.pi)
+    return (start_value + shortest_distance * lerp(0, 1, n)) % max_val
+
+
+def lerp_radians(start_value: float, end_value: float, n: int) -> npt.NDArray[float]:
+    return _lerp_circular(start_value, end_value, n, 2 * np.pi)
+
+
+def lerp_degrees(start_value: float, end_value: float, n: int) -> npt.NDArray[float]:
+    return _lerp_circular(start_value, end_value, n, 360.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.38"
+version = "0.1.39"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = ["Sergio Troncoso <sergio.troncoso@noirlab.edu>",
            "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,7 +5,7 @@ import pytest
 import numpy as np
 
 from lucupy.minimodel import CloudCover
-from lucupy.helpers import lerp, lerp_enum, lerp_radians
+from lucupy.helpers import lerp, lerp_enum, lerp_radians, lerp_degrees
 
 
 @pytest.mark.parametrize('first_value, last_value, n, expected',
@@ -30,9 +30,20 @@ def test_lerp_enum(first_value, last_value, n, expected):
 @pytest.mark.parametrize('first_value, last_value, n, expected',
                          [(np.pi/2, 3*np.pi/2, 4, np.array([0.9424778, 0.31415927, 5.96902604, 5.34070751])),
                           (np.pi/2, -np.pi/2, 4, np.array([0.9424778, 0.31415927, 5.96902604, 5.34070751])),
-                          (np.pi/2 + 1e3, 3*np.pi/2, 4, np.array([2.97794378, 3.41155508, 3.84516638, 4.27877768])),
-                          (np.pi/2 + 1e3, -np.pi/2, 4, np.array([2.97794378, 3.41155508, 3.84516638, 4.27877768])),
+                          (np.pi/2 + 1e-3, 3*np.pi/2, 4, np.array([2.19991486, 2.82803339, 3.45615192, 4.08427045])),
+                          (np.pi/2 + 1e-3, -np.pi/2, 4, np.array([2.19991486, 2.82803339, 3.45615192, 4.08427045])),
                           (np.pi/4, -np.pi/4, 3, np.array([0.39269908, 0, 5.89048623])),
                           (-np.pi/4, np.pi/4, 3, np.array([5.89048623, 0, 0.39269908]))])
 def test_lerp_radians(first_value, last_value, n, expected):
     assert np.allclose(lerp_radians(first_value, last_value, n), expected)
+
+
+@pytest.mark.parametrize('first_value, last_value, n, expected',
+                         [(90, 270, 4, np.array([54, 18, 342, 306])),
+                          (90, -90, 4, np.array([54, 18, 342, 306])),
+                          (90 + 1e-8, 270, 4, np.array([126, 162, 198, 234])),
+                          (90 + 1e-8, -90, 4, np.array([126, 162, 198, 234])),
+                          (60, 300, 3, np.array([30, 0, 330])),
+                          (60, -60, 3, np.array([30, 0, 330]))])
+def test_lerp_degrees(first_value, last_value, n, expected):
+    assert np.allclose(lerp_degrees(first_value, last_value, n), expected)


### PR DESCRIPTION
Adding `lerp_degrees` to try to fix a strange thing happening in OCS weather direction linear interpolation.