### PR TITLE
GSCHED-542: Added Site.resource and site resource to Observation.

### DIFF
--- a/lucupy/minimodel/observation.py
+++ b/lucupy/minimodel/observation.py
@@ -212,7 +212,7 @@ class Observation:
         """
         # TODO: For now, we do not return guiding keys amongst the resources.
         # return frozenset(self.guiding.keys() | {r for a in self.sequence for r in a.resources})
-        return frozenset((r for a in self.sequence for r in a.resources))
+        return frozenset({self.site.resource} | {r for a in self.sequence for r in a.resources})
 
     def instrument(self) -> Optional[Resource]:
         """

--- a/lucupy/minimodel/resource.py
+++ b/lucupy/minimodel/resource.py
@@ -4,15 +4,22 @@
 from dataclasses import dataclass
 from typing import FrozenSet, Optional
 
-from ..decorators import immutable
+from lucupy.decorators import immutable
 
 
 @immutable
 @dataclass(frozen=True)
 class Resource:
     """This is a general observatory resource.
-    It can consist of a guider, an instrument, or a part of an instrument,
-    or even a personnel and is used to determine what observations can be
+    It can consist of
+
+    * a guider;
+    * an instrument;
+    * a part of an instrument;
+    * an observatory (Site); or even
+    * personnel
+
+    and is used to determine what observations can be
     performed at a given time based on the resource availability.
 
     Attributes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.59"
+version = "0.1.60"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = ["Sergio Troncoso <sergio.troncoso@noirlab.edu>",
            "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",


### PR DESCRIPTION
`Site` has been cleaned up considerably.

* There is no need to change the format of the site name for `EarthLocation` lookups. (tested)
* `resource` was added to `Site`.
* Now `location`, `timezone`, and `resource` can be passed into `Site.
* `Observation` now returns its `Site` as one of its required resources. This means no changes need to be made to the Scheduler parsing logic.