### PR TITLE
SCHED-605: Moving Instantiable to lucupy.

### DIFF
--- a/lucupy/types/__init__.py
+++ b/lucupy/types/__init__.py
@@ -1,9 +1,8 @@
 # Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-# Basic type aliases for usefulness.
 from datetime import timedelta
-from typing import Final, List, TypeVar, Union
+from typing import Callable, Final, Generic, List, TypeVar, Union
 
 import numpy.typing as npt
 from astropy.time import Time
@@ -18,3 +17,14 @@ ZeroTime: Final[timedelta] = timedelta()
 
 # Convenient type alias for Interval
 Interval = npt.NDArray[int]
+
+
+class Instantiable(Generic[T]):
+    """
+    Something that calls an instantiable function to defer creation until invoked.
+    """
+    def __init__(self, func: Callable[[], T]):
+        self.func = func
+
+    def __call__(self) -> T:
+        return self.func()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.66"
+version = "0.1.67"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = ["Sergio Troncoso <sergio.troncoso@noirlab.edu>",
            "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",


### PR DESCRIPTION
Moving the `Instantiable` type to lucupy since it has multiple generic uses and will be used in the omegaconf parameters for the Selector's BUFFER as per GSCHED-605.