### PR TITLE
GSCHED-640: fix NIR_INSTRUMENTS

### DIFF
--- a/lucupy/minimodel/resource.py
+++ b/lucupy/minimodel/resource.py
@@ -72,9 +72,9 @@ class Resource:
 
 Resources: TypeAlias = FrozenSet[Resource]
 
-NIR_INSTRUMENTS: Resources = frozenset([Resource('Flamingos2'),
-                                        Resource('GNIRS'),
-                                        Resource('NIRI'),
-                                        Resource('NIFS'),
-                                        Resource('Phoenix'),
-                                        Resource('IGRINS')])
+NIR_INSTRUMENTS: Resources = frozenset([Resource('Flamingos2', type=ResourceType.INSTRUMENT),
+                                        Resource('GNIRS', type=ResourceType.INSTRUMENT),
+                                        Resource('NIRI', type=ResourceType.INSTRUMENT),
+                                        Resource('NIFS', type=ResourceType.INSTRUMENT),
+                                        Resource('Phoenix', type=ResourceType.INSTRUMENT),
+                                        Resource('IGRINS', type=ResourceType.INSTRUMENT)])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.71"
+version = "0.1.72"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = ["Sergio Troncoso <sergio.troncoso@noirlab.edu>",
            "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",


### PR DESCRIPTION
Adding the new type attribute to the NIR_INSTRUMENTS definition is required so that the checks as to whether one of these instruments is in required_resources will work.
This fixes the bug that telluric observations were no longer being scheduled.