### PR TITLE
SCHED-647: Add Day definition.

### DIFF
--- a/lucupy/types/__init__.py
+++ b/lucupy/types/__init__.py
@@ -13,6 +13,7 @@ TimeScalarOrNDArray: TypeAlias = Time | npt.NDArray[float]
 ListOrNDArray: TypeAlias = List[T] | npt.NDArray[T]
 
 ZeroTime: Final[timedelta] = timedelta()
+Day: Final[timedelta] = timedelta(days=1)
 
 # Convenient type alias for Interval
 Interval: TypeAlias = npt.NDArray[int]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.72"
+version = "0.1.73"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = ["Sergio Troncoso <sergio.troncoso@noirlab.edu>",
            "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",


### PR DESCRIPTION
Add definition of a day as a `timedelta`.