### PR TITLE
SCHED-662: Removal of manually created Resources and code simplification

### DIFF
--- a/lucupy/instruments/__init__.py
+++ b/lucupy/instruments/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (c) 2016-2024 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-from .resource_manager import *
+from .instruments import *

--- a/lucupy/instruments/instruments.py
+++ b/lucupy/instruments/instruments.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2016-2024 Association of Universities for Research in Astronomy, Inc. (AURA)
+# For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+from lucupy.resourcemanager import ResourceManager
+from lucupy.minimodel.resource import ResourceType
+
+
+__all__ = [
+    'STANDARD_INSTRUMENTS',
+    'NIR_INSTRUMENTS',
+    'OTHER_INSTRUMENTS',
+    'INSTRUMENTS',
+]
+
+# Obtain Resource from them by going through the ResourceManager.
+rm = ResourceManager()
+
+standard_instruments_names = frozenset({
+    'Flamingos2',
+    'GNIRS',
+    'NIFS',
+    'IGRINS',
+})
+
+STANDARD_INSTRUMENTS = frozenset(rm.lookup_resource(resource_id=inst_name, resource_type=ResourceType.INSTRUMENT)
+                                 for inst_name in standard_instruments_names)
+
+
+# Names of the NIR instruments that do not fall under STANDARD_INSTRUMENTS.
+nir_instrument_names = frozenset({
+    'NIRI',
+    'Phoenix',
+})
+
+NIR_INSTRUMENTS = frozenset(rm.lookup_resource(resource_id=inst_name, resource_type=ResourceType.INSTRUMENT)
+                            for inst_name in nir_instrument_names) | STANDARD_INSTRUMENTS
+
+other_instrument_names = frozenset({
+    'GMOS-N',
+    'GMOS-S',
+    'GPI',
+    'GSAOI',
+})
+
+OTHER_INSTRUMENTS = frozenset(rm.lookup_resource(resource_id=inst_name, resource_type=ResourceType.INSTRUMENT)
+                              for inst_name in other_instrument_names)
+
+
+INSTRUMENTS = NIR_INSTRUMENTS | OTHER_INSTRUMENTS
+
+

--- a/lucupy/minimodel/observation.py
+++ b/lucupy/minimodel/observation.py
@@ -13,12 +13,13 @@ import numpy.typing as npt
 
 from lucupy.types import ZeroTime
 
+from ..instruments import NIR_INSTRUMENTS
 from .atom import Atom
 from .constraints import Constraints
 from .ids import ObservationID, ProgramID, UniqueGroupID
 from .observationmode import ObservationMode
 from .qastate import QAState
-from .resource import NIR_INSTRUMENTS, Resource, Resources
+from .resource import Resource, Resources
 from .site import Site
 from .target import Target, TargetType
 from .too import TooType

--- a/lucupy/minimodel/resource.py
+++ b/lucupy/minimodel/resource.py
@@ -8,7 +8,6 @@ from typing import FrozenSet, Optional, TypeAlias, final
 from lucupy.decorators import immutable
 
 __all__ = [
-    'NIR_INSTRUMENTS',
     'Resource',
     'Resources',
     'ResourceType',
@@ -66,15 +65,11 @@ class Resource:
     def __eq__(self, other):
         return isinstance(other, Resource) and self.id == other.id
 
+    def __hash__(self):
+        return hash(self.id)
+
     def __repr__(self):
         return f"Resource(id='{self.id}')"
 
 
 Resources: TypeAlias = FrozenSet[Resource]
-
-NIR_INSTRUMENTS: Resources = frozenset([Resource('Flamingos2', type=ResourceType.INSTRUMENT),
-                                        Resource('GNIRS', type=ResourceType.INSTRUMENT),
-                                        Resource('NIRI', type=ResourceType.INSTRUMENT),
-                                        Resource('NIFS', type=ResourceType.INSTRUMENT),
-                                        Resource('Phoenix', type=ResourceType.INSTRUMENT),
-                                        Resource('IGRINS', type=ResourceType.INSTRUMENT)])

--- a/lucupy/minimodel/site.py
+++ b/lucupy/minimodel/site.py
@@ -13,6 +13,8 @@ from astropy.coordinates import EarthLocation, UnknownSiteException
 
 from lucupy.decorators import immutable
 from lucupy.minimodel.resource import Resource
+from lucupy.resourcemanager import ResourceManager
+
 
 __all__ = [
     'Site',
@@ -79,7 +81,7 @@ class Site(Enum):
         if resource is not None:
             self.resource = resource
         else:
-            self.resource = Resource(id=site_name)
+            self.resource = ResourceManager().lookup_resource(resource_id=site_name)
 
 
 # A variable to work with all the sites in scheduler components as a frozenset.

--- a/lucupy/observatory/abstract/__init__.py
+++ b/lucupy/observatory/abstract/__init__.py
@@ -51,29 +51,6 @@ class ObservatoryProperties(ABC):
         return cast(ObservatoryProperties, ObservatoryProperties._properties)
 
     @staticmethod
-    def determine_standard_time(resources: Resources,
-                                wavelengths: Wavelengths,
-                                modes: ObservationModes,
-                                cal_length: int) -> Time:
-        """Determine standard time for a specific Observatory
-
-        Args:
-            resources (Resources): Set of Resources(instruments, mask, etc).
-            wavelengths (Wavelengths): An array of Wavelengths to be observed.
-            modes (ObservationModes): The different modes of observation.
-            cal_length (int): The length (in seconds) of a calibration.
-
-        Returns:
-            Time: Value(s) of standard time
-        """
-        return ObservatoryProperties._check().determine_standard_time(
-            resources,
-            wavelengths,
-            modes,
-            cal_length
-        )
-
-    @staticmethod
     def is_instrument(resource: Resource) -> bool:
         """Determine if the given resource is an instrument or not.
 
@@ -84,18 +61,3 @@ class ObservatoryProperties(ABC):
             bool: True is the resource is an instrument of the Observatory, otherwise False.
         """
         return ObservatoryProperties._check().is_instrument(resource)
-
-    @staticmethod
-    def acquisition_time(resource: Resource,
-                         observation_mode: ObservationMode) -> Optional[timedelta]:
-        """Given a resource, check if it is an instrument, and if so, lookup the
-           acquisition time for the specified mode.
-
-        Args:
-            resource (Resource): A resource that should be an Instrument.
-            observation_mode (ObservationMode): The observation mode to be used.
-
-        Returns:
-            Optional[timedelta]: The acquisition time for the instrument in that specific mode.
-        """
-        return ObservatoryProperties._check().acquisition_time(resource, observation_mode)

--- a/lucupy/observatory/gemini/geminiproperties.py
+++ b/lucupy/observatory/gemini/geminiproperties.py
@@ -1,15 +1,10 @@
 # Copyright (c) 2016-2024 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-from enum import Enum, EnumMeta
 from typing import final
 
-import astropy.units as u
-from astropy.time import Time
-
-from lucupy.instruments import *
-from lucupy.minimodel import (ObservationMode, ObservationModes, Resource,
-                              Resources, Wavelengths)
+from lucupy.instruments import INSTRUMENTS
+from lucupy.minimodel import Resource
 from lucupy.observatory.abstract import ObservatoryProperties
 
 __all__ = [
@@ -22,38 +17,6 @@ class GeminiProperties(ObservatoryProperties):
     """
     Implementation of ObservatoryCalculations specific to Gemini.
     """
-
-    @staticmethod
-    def determine_standard_time(resources: Resources,
-                                wavelengths: Wavelengths,
-                                modes: ObservationModes,
-                                cal_length: int) -> Time:
-        """Determine the standard star time required for Gemini.
-
-        Args:
-            resources (Resources): Instruments to be used.
-            wavelengths (Wavelength): Wavelengths to be observed.
-            modes (ObservationModes): Observation modes.
-            cal_length (int): The specific length of a calibration.
-
-        Returns:
-            Time: _description_
-
-        Todo:
-            We may only want to include specific resources, in which case, modify
-            Instruments above to be StandardInstruments.
-        """
-        if cal_length > 1:
-            # Check to see if any of the resources are instruments.
-            if any(resource in STANDARD_INSTRUMENTS for resource in resources):
-                if all(wavelength <= 2.5 for wavelength in wavelengths):
-                    return 1.5 * u.h
-                else:
-                    return 1.0 * u.h
-            if ObservationMode.IMAGING in modes:
-                return 2.0 * u.h
-            return 0.0 * u.h
-
     @staticmethod
     def is_instrument(resource: Resource) -> bool:
         """Checks if the resource is a Gemini instrument.
@@ -65,19 +28,3 @@ class GeminiProperties(ObservatoryProperties):
             bool: True if resource is a Gemini instrument.
         """
         return resource in INSTRUMENTS
-
-    @staticmethod
-    def acquisition_time(resource: Resource,
-                         observation_mode: ObservationMode) -> None:
-        """_summary_
-
-        Args:
-            resource (Resource): Instruments used.
-            observation_mode (ObservationMode): Observation mode.
-
-        Returns:
-            Optional[timedelta]: _description_
-        """
-        if not GeminiProperties.is_instrument(resource):
-            return None
-        ...

--- a/lucupy/observatory/gemini/geminiproperties.py
+++ b/lucupy/observatory/gemini/geminiproperties.py
@@ -7,6 +7,7 @@ from typing import final
 import astropy.units as u
 from astropy.time import Time
 
+from lucupy.instruments import *
 from lucupy.minimodel import (ObservationMode, ObservationModes, Resource,
                               Resources, Wavelengths)
 from lucupy.observatory.abstract import ObservatoryProperties
@@ -18,33 +19,8 @@ __all__ = [
 
 @final
 class GeminiProperties(ObservatoryProperties):
-    """Implementation of ObservatoryCalculations specific to Gemini.
     """
-
-    class _InstrumentsMeta(EnumMeta):
-        """Metaclass for the Instruments Class below.
-        """
-        def __contains__(cls, r: Resource) -> bool:  # type: ignore[override]
-            return any(inst.value.id in r.id for inst in cls.__members__.values())  # type: ignore[var-annotated]
-
-    class Instruments(Enum, metaclass=_InstrumentsMeta):
-        """ Gemini-specific instruments.
-        """
-        FLAMINGOS2 = Resource('Flamingos2')
-        NIFS = Resource('NIFS')
-        NIRI = Resource('NIRI')
-        IGRINS = Resource('IGRINS')
-        GMOS_S = Resource('GMOS-S')
-        GMOS_N = Resource('GMOS-N')
-        GNIRS = Resource('GNIRS')
-        GPI = Resource('GPI')
-        GSAOI = Resource('GSAOI')
-
-    _STANDARD_INSTRUMENTS = [Instruments.FLAMINGOS2,
-                             Instruments.GNIRS,
-                             Instruments.NIFS,
-                             Instruments.IGRINS]
-    """ List: Instruments for which there are set standards.
+    Implementation of ObservatoryCalculations specific to Gemini.
     """
 
     @staticmethod
@@ -66,11 +42,10 @@ class GeminiProperties(ObservatoryProperties):
         Todo:
             We may only want to include specific resources, in which case, modify
             Instruments above to be StandardInstruments.
-
         """
         if cal_length > 1:
             # Check to see if any of the resources are instruments.
-            if any(resource in GeminiProperties._STANDARD_INSTRUMENTS for resource in resources):
+            if any(resource in STANDARD_INSTRUMENTS for resource in resources):
                 if all(wavelength <= 2.5 for wavelength in wavelengths):
                     return 1.5 * u.h
                 else:
@@ -89,7 +64,7 @@ class GeminiProperties(ObservatoryProperties):
         Returns:
             bool: True if resource is a Gemini instrument.
         """
-        return resource in GeminiProperties.Instruments
+        return resource in INSTRUMENTS
 
     @staticmethod
     def acquisition_time(resource: Resource,

--- a/lucupy/resourcemanager/resource_manager.py
+++ b/lucupy/resourcemanager/resource_manager.py
@@ -1,9 +1,17 @@
 # Copyright (c) 2016-2024 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 from typing import Dict, Optional, final
 
 from lucupy.meta import Singleton
-from lucupy.minimodel import Resource, ResourceType
+
+# This needs to be done to break circular import.
+from lucupy.minimodel.resource import Resource, ResourceType
+
+
+_all__ = [
+    'ResourceManager',
+]
 
 
 @final

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.76"
+version = "0.1.77"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = ["Sergio Troncoso <sergio.troncoso@noirlab.edu>",
            "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",


### PR DESCRIPTION
This PR does the following:
* Collectts and distinguishes the instruments, that were spread across multiple files.
* Adds the `hash` dunder method to `Resource`, which should make set `contains` checks not dismiss properly.
* `Site.resource` now created through the `ResourceManager`.
* Big cleanup of `GeminiProperties`, which should be `Resource`s that are instruments that are Gemini-specific.