### PR TITLE
GSCHED: add methods to handle user priority

### DIFF
--- a/lucupy/minimodel/group.py
+++ b/lucupy/minimodel/group.py
@@ -13,7 +13,7 @@ from lucupy.helpers import flatten
 from lucupy.minimodel.constraints import Constraints
 from lucupy.minimodel.ids import (GroupID, ObservationID, ProgramID,
                                   UniqueGroupID)
-from lucupy.minimodel.observation import Observation, ObservationClass
+from lucupy.minimodel.observation import Observation, ObservationClass, ObservationStatus, Priority
 from lucupy.minimodel.resource import Resources
 from lucupy.minimodel.site import Site
 from lucupy.minimodel.wavelength import Wavelengths
@@ -308,6 +308,21 @@ class Group(ABC):
             else:
                 obs_mode = max([child.obs_mode() for child in self.children])
         return obs_mode
+
+    def priority(self) -> Priority:
+        """
+        Return user priority based on those of the children if SCIENCE or PROGCAL
+        :return: priority
+        """
+        priority = Priority.LOW
+        if self.is_and_group():
+            if isinstance(self.children, Observation):
+                if self.children.obs_class in [ObservationClass.SCIENCE, ObservationClass.PROGCAL] and \
+                        self.children.status != ObservationStatus.INACTIVE:
+                    priority = self.children.priority
+            else:
+                priority = max([child.priority() for child in self.children])
+        return priority
 
     def show(self, depth: int = 1) -> None:
         """Print content of the Group.

--- a/lucupy/minimodel/group.py
+++ b/lucupy/minimodel/group.py
@@ -132,15 +132,15 @@ class Group(ABC):
         else:
             return frozenset(w for c in self.children for w in c.wavelengths())
 
-    def constraints(self) -> FrozenSet[Constraints]:
+    def constraints(self) -> List[Constraints]:
         """
         Returns:
-            FrozenSet[Constraints]: All set of Constraints of children in the group.
+            List[Constraints]: All set of Constraints of children in the group.
         """
         if isinstance(self.children, Observation):
-            return frozenset([self.children.constraints])
+            return [self.children.constraints]
         else:
-            return frozenset(cs for c in self.children for cs in c.constraints())
+            return [cs for c in self.children for cs in c.constraints()]
 
     def observations(self) -> List[Observation]:
         """

--- a/lucupy/minimodel/program.py
+++ b/lucupy/minimodel/program.py
@@ -6,8 +6,11 @@ from datetime import datetime, timedelta
 from enum import Enum, IntEnum, auto
 from typing import ClassVar, FrozenSet, List, Optional, final
 
+import numpy as np
+
 from lucupy.decorators import immutable
 from lucupy.types import ZeroTime
+from lucupy.minimodel import Priority
 
 from .group import ROOT_GROUP_ID, AndGroup, Group
 from .ids import ObservationID, ProgramID, UniqueGroupID
@@ -189,6 +192,14 @@ class Program:
                             return check_subgroup
                     return None
         return aux(self.root_group)
+
+    def effective_priority(self):
+        priorities = []
+        for obs in self.observations():
+            priorities.append(obs.priority.value)
+        mean_priority = np.mean(priorities)
+        eff_priority = int(mean_priority + 0.5)
+        return Priority(eff_priority)
 
     def show(self):
         """Print content of the Program.

--- a/lucupy/minimodel/program.py
+++ b/lucupy/minimodel/program.py
@@ -14,7 +14,7 @@ from lucupy.minimodel import Priority
 
 from .group import ROOT_GROUP_ID, AndGroup, Group
 from .ids import ObservationID, ProgramID, UniqueGroupID
-from .observation import Observation
+from .observation import Observation, ObservationClass, ObservationStatus, Priority
 from .semester import Semester
 from .timeallocation import TimeAllocation
 from .too import TooType
@@ -193,13 +193,22 @@ class Program:
                     return None
         return aux(self.root_group)
 
-    def effective_priority(self):
+    def mean_priority(self) -> float:
+        """
+        Return the mean user priority from the active SCIENCE and PROGCAL observations
+        :return: float
+        """
+        mean_priority = 1.0
         priorities = []
         for obs in self.observations():
-            priorities.append(obs.priority.value)
-        mean_priority = np.mean(priorities)
-        eff_priority = int(mean_priority + 0.5)
-        return Priority(eff_priority)
+            if obs.obs_class in [ObservationClass.SCIENCE, ObservationClass.PROGCAL] and \
+                    obs.status != ObservationStatus.INACTIVE:
+                priorities.append(obs.priority.value)
+
+        if len(priorities) > 0:
+            mean_priority = np.mean(priorities)
+
+        return mean_priority
 
     def show(self):
         """Print content of the Program.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.81"
+version = "0.1.82"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = ["Sergio Troncoso <sergio.troncoso@noirlab.edu>",
            "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",


### PR DESCRIPTION
Calculate effective user priority for groups and the program based on the observation settings.
Based only on active science and program calibration observations.
The program mean priority is used in the scoring algorithm.
Returned group constraints are a list now rather than a frozenset.
