### PR TITLE
SCHED-650: Cleanup for priorities and observation filtering.

### DIFF
--- a/lucupy/minimodel/__init__.py
+++ b/lucupy/minimodel/__init__.py
@@ -10,6 +10,7 @@ from .constraints import *
 from .group import *
 from .ids import *
 from .magnitude import *
+from .obs_filter import *
 from .observation import *
 from .observationmode import *
 from .program import *

--- a/lucupy/minimodel/obs_filter.py
+++ b/lucupy/minimodel/obs_filter.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2016-2024 Association of Universities for Research in Astronomy, Inc. (AURA)
+# For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+from .observation import Observation, ObservationClass, ObservationStatus
+
+
+__all__ = [
+    'obs_is_science_or_progcal',
+    'obs_is_not_inactive',
+]
+
+
+_OBS_CLASSES = frozenset({ObservationClass.SCIENCE, ObservationClass.PROGCAL})
+
+
+def obs_is_science_or_progcal(obs: Observation) -> bool:
+    """
+    Return True if the Observation is a SCIENCE or PROGCAL observation.
+    :param obs: the Observation to check
+    :return: True if the Observation is a SCIENCE or PROGCAL observation and False otherwise
+    """
+    return obs.obs_class in _OBS_CLASSES
+
+
+def obs_is_not_inactive(obs: Observation) -> bool:
+    """
+    Return True if the Observation is not INACTIVE.
+    :param obs: the Observation to check
+    :return: True if Observation is not INACTIVE and False otherwise
+    """
+    return obs.status != ObservationStatus.INACTIVE

--- a/lucupy/minimodel/observation.py
+++ b/lucupy/minimodel/observation.py
@@ -71,16 +71,18 @@ class ObservationStatus(IntEnum):
 @final
 class Priority(IntEnum):
     """An observation's priority.
-    Note that these are ordered specifically so that we can compare them.
+    Note that these are ordered specifically so that we can compare them, and assigned
+    specific int values so that we can sum over them to get a Program's mean priority over
+    its Observations and get a value in the interval [LOW.value, HIGH.value].
 
     Members:
         - LOW
         - MEDIUM
         - HIGH
     """
-    LOW = auto()
-    MEDIUM = auto()
-    HIGH = auto()
+    LOW = 0
+    MEDIUM = 1
+    HIGH = 2
 
 
 @final

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.82"
+version = "0.1.83"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = ["Sergio Troncoso <sergio.troncoso@noirlab.edu>",
            "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",


### PR DESCRIPTION
This PR does the following:
* Adds common filters for `Observation` (done to avoid recreating a `FrozenSet[ObservationClass]` with every loop index).
* Generalizes the logic for fetching `List[Observation]`.
* Adds values to `Priority` so that we can get a mean priority score for a `Program`.