### PR TITLE
Change default max airmass to 2.05

### DIFF
--- a/lucupy/minimodel/constraints.py
+++ b/lucupy/minimodel/constraints.py
@@ -250,7 +250,7 @@ class Constraints:
     # 1. The Constraints are not present in the Observation at all; or
     # 2. The elevation_type is set to NONE.
     DEFAULT_AIRMASS_ELEVATION_MIN: ClassVar[float] = field(init=False, default=1.0, repr=False, compare=False)
-    DEFAULT_AIRMASS_ELEVATION_MAX: ClassVar[float] = field(init=False, default=2.3, repr=False, compare=False)
+    DEFAULT_AIRMASS_ELEVATION_MAX: ClassVar[float] = field(init=False, default=2.05, repr=False, compare=False)
 
 
 @final

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.85"
+version = "0.1.86"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = [
     "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",


### PR DESCRIPTION
This should be more in agreement with what QCs use. Observations that must be done at higher airmass need the constraint set in the observation in the OT.