### PR TITLE
SCHED-679: Fixing Moon low precision calculations

### DIFF
--- a/lucupy/sky/brightness.py
+++ b/lucupy/sky/brightness.py
@@ -39,7 +39,7 @@ def calculate_sky_brightness(moon_phase_angle: Angle,
     Args:
         moon_phase_angle: Moon phase angles in degrees
         target_moon_angdist: Angular distances between target and moon
-        earth_moon_dist: Distances from the Earth to the Moon
+        earth_moon_dist: Distances from the Earth to the Moon in m
         moon_zenith_distang: Moon zenith distance angles
         target_zenith_distang: Target zenith distance angles
         sun_zenith_distang: Sun zenith distance angles

--- a/lucupy/sky/moon.py
+++ b/lucupy/sky/moon.py
@@ -287,7 +287,7 @@ class Moon:
         self.beta = Angle(np.deg2rad(beta), unit=u.rad)
         self.lambd = Angle(np.deg2rad(lambd), unit=u.rad)
 
-    def low_precision_location(self, obs: EarthLocation) -> Tuple[SkyCoord, float]:
+    def low_precision_location(self, obs: EarthLocation) -> Tuple[SkyCoord, Distance]:
         """This is the same as the high precision method, but with a different set of coefficients.
         The difference is small. Good to about 0.1 deg, from the 1992 Astronomical Almanac, p. D46.
         Note that input time is a float.
@@ -296,7 +296,7 @@ class Moon:
             obs: Earth location of the observation.
 
         Returns:
-            Tuple[SkyCoord, float]: Moon coordinates and topographic distance.
+            Tuple[SkyCoord, Distance]: Moon coordinates and topographic distance.
         """
         self._low_precision_calculations()
 
@@ -328,9 +328,10 @@ class Moon:
         distancemultiplier = Distance(EQUAT_RAD, unit=u.m)
 
         fr = current_geocent_frame(self.time)
-        return SkyCoord(alpha, delta, topo_dist * distancemultiplier, frame=fr), topo_dist
+        return (SkyCoord(alpha, delta, topo_dist * distancemultiplier, frame=fr),
+                Distance(topo_dist * u.m))
 
-    def accurate_location(self, obs: EarthLocation) -> Tuple[SkyCoord, float]:
+    def accurate_location(self, obs: EarthLocation) -> Tuple[SkyCoord, Distance]:
         """Compute topocentric location and distance of moon to better accuracy.
 
         This is good to about 0.01 degrees.
@@ -383,7 +384,8 @@ class Moon:
             decout = np.squeeze(decout)
             topo_dist = np.squeeze(topo_dist)
 
-        return SkyCoord(raout, decout, unit=u.rad, frame=current_geocent_frame(self.time)), topo_dist
+        return (SkyCoord(raout, decout, unit=u.rad, frame=current_geocent_frame(self.time)),
+                Distance(topo_dist * u.m))
 
     @staticmethod
     def time_by_altitude(alt: Angle,

--- a/lucupy/sky/moon.py
+++ b/lucupy/sky/moon.py
@@ -325,11 +325,11 @@ class Moon:
 
         alpha = np.arctan2(m, ell)
         delta = np.arcsin(n)
-        # distancemultiplier = Distance(EQUAT_RAD, unit=u.m)
+        distancemultiplier = Distance(EQUAT_RAD, unit=u.m)
 
         fr = current_geocent_frame(self.time)
-        # return SkyCoord(alpha, delta, topo_dist * distancemultiplier, frame=fr)
-        return SkyCoord(alpha, delta, topo_dist, frame=fr), Distance(topo_dist * EQUAT_RAD)
+        final_dist = topo_dist * distancemultiplier
+        return SkyCoord(alpha, delta, final_dist, frame=fr), final_dist
 
     def accurate_location(self, obs: EarthLocation) -> Tuple[SkyCoord, Distance]:
         """Compute topocentric location and distance of moon to better accuracy.

--- a/lucupy/sky/moon.py
+++ b/lucupy/sky/moon.py
@@ -287,7 +287,7 @@ class Moon:
         self.beta = Angle(np.deg2rad(beta), unit=u.rad)
         self.lambd = Angle(np.deg2rad(lambd), unit=u.rad)
 
-    def low_precision_location(self, obs: EarthLocation) -> SkyCoord:
+    def low_precision_location(self, obs: EarthLocation) -> Tuple[SkyCoord, Distance]:
         """This is the same as the high precision method, but with a different set of coefficients.
         The difference is small. Good to about 0.1 deg, from the 1992 Astronomical Almanac, p. D46.
         Note that input time is a float. It also only calculates the sky coordinates.
@@ -329,7 +329,7 @@ class Moon:
 
         fr = current_geocent_frame(self.time)
         # return SkyCoord(alpha, delta, topo_dist * distancemultiplier, frame=fr)
-        return SkyCoord(alpha, delta, topo_dist, frame=fr)
+        return SkyCoord(alpha, delta, topo_dist, frame=fr), Distance(topo_dist * EQUAT_RAD)
 
     def accurate_location(self, obs: EarthLocation) -> Tuple[SkyCoord, Distance]:
         """Compute topocentric location and distance of moon to better accuracy.
@@ -474,7 +474,7 @@ class Moon:
         Returns:
             Tuple[Time, Time]: Moonrise and Moonset values, in that order.
         """
-        moon_at_midnight = self.at(midnight).low_precision_location(location)
+        moon_at_midnight, _ = self.at(midnight).low_precision_location(location)
         lst_midnight = local_sidereal_time(midnight, location)
         ha_moon_at_midnight = lst_midnight - moon_at_midnight.ra
         ha_moon_at_midnight.wrap_at(12. * u.hour, inplace=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.87"
+version = "0.1.88"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = [
     "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",

--- a/tests/test_moon.py
+++ b/tests/test_moon.py
@@ -6,6 +6,7 @@ import numpy.testing as nptest
 import pytest
 from astropy.time import Time
 
+from lucupy.sky.constants import EQUAT_RAD
 from lucupy.sky.moon import Moon
 
 from .fixtures import location, test_time
@@ -32,9 +33,10 @@ def test_moon_low_precision_location(moon, location):
     """
     Test that the moon location is accurate.
     """
-    loc = moon.low_precision_location(location)
+    loc, dist = moon.low_precision_location(location)
     nptest.assert_almost_equal(loc.ra.deg, 228.41771177093597, decimal=5)
     nptest.assert_almost_equal(loc.dec.deg, -15.297127679461509, decimal=5)
+    nptest.assert_almost_equal(dist.value, (57.34667914568056 * EQUAT_RAD).value, decimal=5)
 
 
 @pytest.mark.usefixtures("test_time", "location")

--- a/tests/test_moon.py
+++ b/tests/test_moon.py
@@ -32,10 +32,9 @@ def test_moon_low_precision_location(moon, location):
     """
     Test that the moon location is accurate.
     """
-    loc, dist = moon.low_precision_location(location)
+    loc = moon.low_precision_location(location)
     nptest.assert_almost_equal(loc.ra.deg, 228.41771177093597, decimal=5)
     nptest.assert_almost_equal(loc.dec.deg, -15.297127679461509, decimal=5)
-    nptest.assert_almost_equal(dist.value, 57.34667914568056, decimal=5)
 
 
 @pytest.mark.usefixtures("test_time", "location")


### PR DESCRIPTION
This PR does two things:
1. It returns a `Distance` (in m) instead of a `float` in calculating the moon distance in high precision calculations.
2. It returns the `Distance` (in m) instead of `float` (originally calculated in equatorial radii) calculated in the moon distance in low precision calculations.