### PR TITLE
GSCHED-683: MAJOR_BODY to MAJORBODY

### DIFF
--- a/lucupy/minimodel/target.py
+++ b/lucupy/minimodel/target.py
@@ -68,7 +68,7 @@ class TargetTag(Enum):
     """
     COMET = auto()
     ASTEROID = auto()
-    MAJOR_BODY = auto()
+    MAJORBODY = auto()
 
 
 @immutable


### PR DESCRIPTION
To be consistent with the format in the new program data, `MAJOR_BODY` is now represented as `MAJORBODY`.