### PR TITLE
Update instrument set definitions to fix scheduling of tellurics

### DIFF
--- a/lucupy/observatory/gemini/geminiproperties.py
+++ b/lucupy/observatory/gemini/geminiproperties.py
@@ -47,19 +47,19 @@ class GeminiProperties(ObservatoryProperties):
         GSAOI = rm.lookup_resource(rid='GSAOI', rtype=ResourceType.INSTRUMENT)
         PHOENIX = rm.lookup_resource(rid='Phoenix', rtype=ResourceType.INSTRUMENT)
 
-    _STANDARD_INSTRUMENTS = frozenset({Instruments.FLAMINGOS2,
-                                       Instruments.GNIRS,
-                                       Instruments.NIFS,
-                                       Instruments.IGRINS,
-                                       Instruments.GMOS_N,
-                                       Instruments.GMOS_S})
+    _STANDARD_INSTRUMENTS = frozenset({Instruments.FLAMINGOS2.value,
+                                       Instruments.GNIRS.value,
+                                       Instruments.NIFS.value,
+                                       Instruments.IGRINS.value,
+                                       Instruments.GMOS_N.value,
+                                       Instruments.GMOS_S.value})
 
-    _NIR_INSTRUMENTS: Resources = frozenset({Instruments.FLAMINGOS2,
-                                             Instruments.GNIRS,
-                                             Instruments.NIRI,
-                                             Instruments.NIFS,
-                                             Instruments.PHOENIX,
-                                             Instruments.IGRINS})
+    _NIR_INSTRUMENTS: Resources = frozenset({Instruments.FLAMINGOS2.value,
+                                             Instruments.GNIRS.value,
+                                             Instruments.NIRI.value,
+                                             Instruments.NIFS.value,
+                                             Instruments.PHOENIX.value,
+                                             Instruments.IGRINS.value})
 
     """ List: Instruments for which there are set standards.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.1.95"
+version = "0.1.96"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = [
     "Sebastian Raaphorst <sebastian.raaphorst@noirlab.edu>",


### PR DESCRIPTION
The previous definition of the lists of Gemini instruments put them in a class and so the sets of instrument types became sets of the Instruments class instead of sets of Resources. Therefore, GreedyMax could not identify whether an observation used a NIR instrument and did not process the tellurics correctly, not scheduling them. This change makes _STANDARD_INSTRUMENTS and _NIR_INSTRUMENTS sets of Resources so that they can be compares to the observation Resources.