### PR TITLE
GSCHED-870: add calibration_role and system_group

### DIFF
--- a/lucupy/minimodel/group.py
+++ b/lucupy/minimodel/group.py
@@ -7,14 +7,14 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum, auto
-from typing import Final, FrozenSet, List, Optional, Callable
+from typing import Final, FrozenSet, List, Optional, Callable, Set
 
 from lucupy.helpers import flatten
 from lucupy.minimodel.constraints import Constraints
 from lucupy.minimodel.ids import (GroupID, ObservationID, ProgramID,
                                   UniqueGroupID)
 from lucupy.minimodel.obs_filter import obs_is_not_inactive, obs_is_science_or_progcal
-from lucupy.minimodel.observation import Observation, ObservationClass, Priority, Band
+from lucupy.minimodel.observation import Observation, ObservationClass, Priority, Band, CalibrationRole
 from lucupy.minimodel.resource import Resources
 from lucupy.minimodel.site import Site
 from lucupy.minimodel.wavelength import Wavelengths
@@ -410,6 +410,8 @@ class Group(BaseGroup):
     group_option: AndOption
     previous: Optional[int] = None
     parent_index: Optional[int] = None
+    calibration_role: Optional[CalibrationRole] = None
+    system_group: Optional[bool] = False
 
     def __post_init__(self):
         super().__post_init__()

--- a/lucupy/minimodel/observation.py
+++ b/lucupy/minimodel/observation.py
@@ -32,7 +32,26 @@ __all__ = [
     'ObservationStatus',
     'Priority',
     'SetupTimeType',
+    'CalibrationRole',
 ]
+
+
+@final
+class CalibrationRole(Enum):
+    """
+    The calibration role of an observation, from GPP.
+
+    Members:
+        - NONE
+        - TWILIGHT
+        - PHOTOMETRIC
+        - SPECTROPHOTOMETRIC
+        - TELLURIC
+    """
+    TWILIGHT = auto()
+    PHOTOMETRIC = auto()
+    SPECTROPHOTOMETRIC = auto()
+    TELLURIC = auto()
 
 
 @final
@@ -193,6 +212,7 @@ class Observation:
     too_type: Optional[TooType] = None
     preimaging: bool = False
     band: Optional[Band] = None
+    calibration_role: CalibrationRole = None
 
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.2.7"
+version = "0.2.8"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = [
     "Sergio Troncoso <sergio.troncoso@noirlab.edu>",


### PR DESCRIPTION
Add new attributes to observations and groups in order to identify Telluric observation and calibration groups without only parsing the titles.