### PR TITLE
GSCHED-862/970: add seq steps to visits

### DIFF
--- a/lucupy/minimodel/atom.py
+++ b/lucupy/minimodel/atom.py
@@ -52,3 +52,5 @@ class Atom:
     resources: Resources
     wavelengths: Wavelengths
     obs_mode: ObservationMode
+    step_start: int = None
+    step_count: int = None

--- a/lucupy/minimodel/group.py
+++ b/lucupy/minimodel/group.py
@@ -354,7 +354,8 @@ class BaseGroup(ABC):
         print(f'{sep(depth)} Group: {self.id.id}, unique_id={self.unique_id.id}, parent={self.parent_id.id}, '
               # f'parent_index={self.parent_index}, '
               f'previous={self.previous_id.id}, next={self.next_id.id}, active={self.active}, '              
-              f'({group_type}, num_children={len(self.children)}, num_observe={self.number_to_observe})')
+              f'({group_type}, num_children={len(self.children)}, num_observe={self.number_to_observe}, '
+              f'num_observed={self.number_observed})')
         if isinstance(self.children, Observation):
             self.children.show(depth + 1)
         else:

--- a/lucupy/minimodel/observation.py
+++ b/lucupy/minimodel/observation.py
@@ -427,7 +427,8 @@ class Observation:
         def sep(indent: int) -> str:
             return '-----' * indent
 
-        print(f'{sep(depth)} Observation: {self.id.id} {self.status.name}')
+        band = self.band.name if self.band else 'None'
+        print(f'{sep(depth)} Observation: {self.id.id} {self.status.name} {band} {self.obs_class.name}')
         for atom in self.sequence:
             print(f'{sep(depth + 1)} {atom}')
 

--- a/lucupy/minimodel/timingwindow.py
+++ b/lucupy/minimodel/timingwindow.py
@@ -2,7 +2,8 @@
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from astropy.time import Time
+from datetime import timedelta
 from typing import ClassVar, Optional, final
 
 from ..decorators import immutable
@@ -19,12 +20,12 @@ class TimingWindow:
     """Representation of timing windows in the mini-model.
 
     Attributes:
-        start (datetime): When a timing window begins.
+        start (Time): When a timing window begins. Time objects used by calculator.py and the program providers
         duration (timedelta): For infinite duration, set duration to timedelta.max.
         repeat (int):  -1 means forever repeating, 0 means non-repeating.
         period (timedelta, optional): None should be used if repeat < 1.
     """
-    start: datetime
+    start: Time
     duration: timedelta
     repeat: int
     period: Optional[timedelta]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lucupy"
-version = "0.2.8"
+version = "0.2.9"
 description = "Lucuma core package for the Gemini Automated Scheduler at: https://github.com/gemini-hlsw/scheduler"
 authors = [
     "Sergio Troncoso <sergio.troncoso@noirlab.edu>",


### PR DESCRIPTION
Mostly this adds step_start and step_count to the atom class so that we can propagate the steps in the scheduled atoms to the output visits.  Also, it updates some of the program/groups/observation display output in order to review these changes and work towards group time accounting in the simulation mode.